### PR TITLE
Update Astro component imports

### DIFF
--- a/astro/BPMDetector.astro
+++ b/astro/BPMDetector.astro
@@ -83,7 +83,7 @@ const {
 </style>
 
 <script>
-  import { detectBPM } from '../src/index.js';
+  import { detectBPM } from 'pleco-xa/src/index.js';
 
   document.addEventListener('DOMContentLoaded', () => {
     const fileInput = document.getElementById('bpmFileInput');

--- a/astro/PlecoAnalyzer.astro
+++ b/astro/PlecoAnalyzer.astro
@@ -142,7 +142,7 @@ const {
     computeSpectralCentroid,
     computeRMS,
     LoopPlayer 
-  } from '../src/index.js';
+  } from 'pleco-xa/src/index.js';
 
   let currentPlayer = null;
 

--- a/astro/WaveformEditor.astro
+++ b/astro/WaveformEditor.astro
@@ -112,7 +112,7 @@ const {
 </style>
 
 <script>
-  import { librosaLoopAnalysis, WaveformEditor, LoopPlayer } from '../src/index.js';
+  import { librosaLoopAnalysis, WaveformEditor, LoopPlayer } from 'pleco-xa/src/index.js';
 
   let editor = null;
   let player = null;


### PR DESCRIPTION
## Summary
- reference the package entry when importing library functions in astro components

## Testing
- `npm pack --dry-run`
- `node -e "import { detectBPM } from 'pleco-xa/src/index.js'; console.log(typeof detectBPM);"`