### PR TITLE
Add Jest test for detectBPM

### DIFF
--- a/src/__tests__/bpm-detector.test.js
+++ b/src/__tests__/bpm-detector.test.js
@@ -1,0 +1,14 @@
+import { detectBPM } from '../core/bpm-detector.js';
+
+describe('detectBPM', () => {
+  it('returns an object with bpm and confidence', () => {
+    const sampleRate = 44100;
+    const length = sampleRate * 2; // 2 seconds of silence
+    const audioData = new Float32Array(length).fill(0);
+
+    const result = detectBPM(audioData, sampleRate);
+
+    expect(result).toHaveProperty('bpm');
+    expect(result).toHaveProperty('confidence');
+  });
+});


### PR DESCRIPTION
## Summary
- add a basic Jest test for the `detectBPM` function to check returned keys

## Testing
- `npm test` *(fails: `jest` not found)*