### PR TITLE
Fix bpm event name

### DIFF
--- a/astro/BPMDetector.astro
+++ b/astro/BPMDetector.astro
@@ -113,7 +113,7 @@ const {
           }
           
           // Dispatch event
-          const bpmEvent = new CustomEvent('bpmDetected', {
+          const bpmEvent = new CustomEvent('bpmEvent', {
             detail: { bpm: result.bpm, confidence: result.confidence }
           });
           document.dispatchEvent(bpmEvent);


### PR DESCRIPTION
## Summary
- rename `bpmDetected` event to `bpmEvent` in BPMDetector

## Testing
- `npx jest` *(fails: EHOSTUNREACH)*