### PR TITLE
Add BPM detector test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "jest"
   },
   "keywords": [
     "audio",

--- a/src/__tests__/bpm-detector.test.js
+++ b/src/__tests__/bpm-detector.test.js
@@ -1,14 +1,29 @@
 import { detectBPM } from '../core/bpm-detector.js';
 
+function createPulseSample(bpm, sampleRate, durationSeconds) {
+  const length = Math.floor(sampleRate * durationSeconds);
+  const data = new Float32Array(length);
+  const samplesPerBeat = sampleRate * 60 / bpm;
+
+  for (let i = 0; i < length; i += samplesPerBeat) {
+    data[Math.floor(i)] = 1; // simple impulse on each beat
+  }
+
+  return data;
+}
+
 describe('detectBPM', () => {
-  it('returns an object with bpm and confidence', () => {
+  it('returns an object with bpm and confidence for a short synthetic sample', () => {
     const sampleRate = 44100;
-    const length = sampleRate * 2; // 2 seconds of silence
-    const audioData = new Float32Array(length).fill(0);
+    const audioData = createPulseSample(120, sampleRate, 2);
 
     const result = detectBPM(audioData, sampleRate);
 
-    expect(result).toHaveProperty('bpm');
-    expect(result).toHaveProperty('confidence');
+    expect(result).toEqual(
+      expect.objectContaining({
+        bpm: expect.any(Number),
+        confidence: expect.any(Number),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- create a small synthetic pulse generator test for `detectBPM`
- add `npm test` script so Jest runs with `npm test`

## Testing
- `npm test` *(fails: jest not found)*