### PR TITLE
Fix LoopPlayer export clash

### DIFF
--- a/astro/index.js
+++ b/astro/index.js
@@ -7,7 +7,8 @@
 export { default as PlecoAnalyzer } from './PlecoAnalyzer.astro';
 export { default as WaveformEditor } from './WaveformEditor.astro';
 export { default as BPMDetector } from './BPMDetector.astro';
-export { default as LoopPlayer } from './LoopPlayer.astro';
+// Avoid name collision with LoopPlayer class exported from src
+export { default as LoopPlayerComponent } from './LoopPlayer.astro';
 
 // Re-export core functions for convenience
 export * from '../src/index.js';


### PR DESCRIPTION
## Summary
- avoid re-exporting LoopPlayer name from astro index

## Testing
- `npm run build` *(fails: rollup not found)*