### PR TITLE
Fix README about package privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,12 @@ npm run build
 npm publish
 ```
 
-Update the package version in `package.json` before publishing. The project is
-marked as `private`; remove that flag if releasing publicly.
+Update the package version in `package.json` before publishing. The package can
+be installed with `npm install pleco-xa` and is ready to publish with `npm publish`.
 
 ## Contributing
 
-This is a private repository. For access or questions, contact Cameron Brooks.
+Contributions are welcome! Feel free to open issues or pull requests on GitHub.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update instructions for publishing the package
- remove references to the repo being private

## Testing
- `npm test` *(fails: jest not found)*