### PR TITLE
Add terser default import in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,20 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
 
 export default {
   input: 'src/index.js',
-  output: {
-    file: 'dist/index.js',
-    format: 'esm',
-    sourcemap: true
-  },
+  output: [
+    {
+      file: 'dist/pleco-xa.js',
+      format: 'esm',
+      sourcemap: true
+    },
+    {
+      file: 'dist/pleco-xa.min.js',
+      format: 'esm',
+      sourcemap: true,
+      plugins: [terser()]
+    }
+  ],
   plugins: [nodeResolve()]
 };


### PR DESCRIPTION
## Summary
- import terser as the default export
- output both regular and minified bundles

## Testing
- `npm run build` *(fails: rollup not found)*
- `npx jest` *(fails: command not found)*