### PR TITLE
Fix example import and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ const editor = new WaveformEditor(canvas, audioBuffer, analysis);
 
 ## Build
 
-Run `npm run build` to generate distributable bundles in the `dist/` directory.
-This produces `dist/pleco-xa.js` and a minified `dist/pleco-xa.min.js` ready for
-use in the browser or with bundlers. The `prepublishOnly` script defined in
+Run `npm run build` to generate the distributable bundle in the `dist/`
+directory. The build outputs `dist/index.js`, which can be used directly in the
+browser or with bundlers. The `prepublishOnly` script defined in
 `package.json` automatically runs this build step before the package is
 published.
 

--- a/examples/basic-usage.html
+++ b/examples/basic-usage.html
@@ -71,7 +71,7 @@
       computeRMS,
       computePeak,
       LoopPlayer
-    } from '../dist/pleco-xa.min.js';
+    } from '../dist/index.js';
 
     let currentPlayer = null;
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,20 +1,11 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
 
 export default {
   input: 'src/index.js',
-  output: [
-    {
-      file: 'dist/pleco-xa.js',
-      format: 'esm',
-      sourcemap: true
-    },
-    {
-      file: 'dist/pleco-xa.min.js',
-      format: 'esm',
-      sourcemap: true,
-      plugins: [terser()]
-    }
-  ],
+  output: {
+    file: 'dist/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
   plugins: [nodeResolve()]
 };


### PR DESCRIPTION
## Summary
- clarify the build output location in the README
- update the basic usage example to import from the new build path
- simplify rollup config to output only `dist/index.js`

## Testing
- `npm test` *(fails: jest not found)*