### PR TITLE
Add Stripe serverless deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,22 @@ See the `/examples` directory for complete working examples:
   transitions as you scroll. Place `loop1.mp3` and `loop2.mp3` in the
   `examples` directory to try it locally.
 
+## Deploying with Stripe Checkout
+
+Example serverless functions for integrating Pleco Xa with Stripe Checkout are provided in [deploying/railway-api](deploying/railway-api/). This example uses [Railway](https://railway.app/) to deploy two endpoints:
+- `createSession.js` – creates a Checkout session
+- `success.js` – verifies the payment and returns a signed token
+
+### Setup
+1. Install the Railway CLI and run `railway init` inside the `deploying/railway-api` folder.
+2. Configure these environment variables:
+   - `STRIPE_SECRET` – your Stripe secret key
+   - `PREMIUM_PRICE_ID` – the Stripe price ID
+   - `PREMIUM_TOKEN_SECRET` – secret used to sign tokens
+   - `BASE_URL` – public URL of your site
+
+Deploy with `railway up` and integrate the token with `paywall.js`. See [deploying/README.md](deploying/README.md) for more details.
+
 ## Browser Compatibility
 
 Pleco Xa works in all modern browsers that support:

--- a/deploying/README.md
+++ b/deploying/README.md
@@ -16,6 +16,15 @@ features.
 
    - `BASE_URL` – public URL of your static site (e.g. `https://pleco-xa.com`)
 
+Example `.env` file:
+
+```bash
+STRIPE_SECRET=sk_test_your_key
+PREMIUM_PRICE_ID=price_123
+PREMIUM_TOKEN_SECRET=your_token_secret
+BASE_URL=https://your-site.com
+```
+
 ## 2. Deploy the API
 
 The `railway-api` directory defines two serverless endpoints:


### PR DESCRIPTION
## Summary
- add `Deploying with Stripe Checkout` section to README
- include Railway environment variable example in deploying docs

## Testing
- `npm test` *(fails: Jest failed to parse bun modules)*