### PR TITLE
Update README testing details

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Run the Jest test suite with:
 ```bash
 npm test
 ```
+Make sure to install dependencies first using `npm ci` (or `npm install`). The test script uses the `--experimental-vm-modules` flag so Jest can run ES modules.
 
 This command executes all tests configured in `jest.config.cjs`.
 ## Astro Integration


### PR DESCRIPTION
## Summary
- add note about installing dependencies before running tests
- explain use of `--experimental-vm-modules` flag for ES modules

## Testing
- `npm test` *(fails: Cannot find module 'bun:test'; SyntaxError in loopAnalysis.test.ts)*