### PR TITLE
Add terser named import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
+import { terser } from '@rollup/plugin-terser';
 
 const basePlugins = [nodeResolve()];
 


### PR DESCRIPTION
## Summary
- change terser import to use named syntax

## Testing
- `npm run build` *(fails: The requested module '@rollup/plugin-terser' does not provide an export named 'terser')*