### PR TITLE
Fix terser import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import { terser } from '@rollup/plugin-terser';
+import terser from '@rollup/plugin-terser';
 
 const basePlugins = [nodeResolve()];
 


### PR DESCRIPTION
## Summary
- use the default import for the terser plugin

## Testing
- `npm run build`
