### PR TITLE
Update README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Run the Jest test suite with:
 npm test
 ```
 
-This command executes all tests configured in `jest.config.cjs`. Make sure to
-install dependencies with `npm ci` before running tests. The test script uses
+This command executes all tests configured in `jest.config.cjs`. Before running
+`npm test`, install dependencies with `npm ci` or `npm install`. Tests run with
 Node's `--experimental-vm-modules` flag to enable ES modules.
 ## Astro Integration
 


### PR DESCRIPTION
## Summary
- add clarifications about installing dependencies before running tests
- document that tests run with the `--experimental-vm-modules` flag

## Testing
- `npm test`