### PR TITLE
Align Node version for Railway

### DIFF
--- a/deploying/railway-api/.nixpacks.toml
+++ b/deploying/railway-api/.nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["nodejs-22_x"]
+nixPkgs = ["nodejs-20_x"]
 
 [phases.install]
 cmds = ["npm ci"]

--- a/deploying/railway-api/package.json
+++ b/deploying/railway-api/package.json
@@ -8,5 +8,8 @@
   },
   "scripts": {
     "start": "node server.js"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }


### PR DESCRIPTION
## Summary
- pin nodejs 20 in the Railway nixpacks file
- add an `engines` field for Node 20 in the Railway API `package.json`

## Testing
- `npm test`