### PR TITLE
Add debug flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install pleco-xa
 ## Quick Start
 
 ```javascript
-import { detectBPM, librosaLoopAnalysis, WaveformEditor } from 'pleco-xa';
+import { detectBPM, librosaLoopAnalysis, WaveformEditor, debugLog } from 'pleco-xa';
 
 // Load audio file
 const audioContext = new AudioContext();
@@ -55,12 +55,12 @@ const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
 
 // Detect BPM
 const bpmResult = detectBPM(audioBuffer.getChannelData(0), audioBuffer.sampleRate);
-console.log(`Detected BPM: ${bpmResult.bpm}`);
+debugLog(`Detected BPM: ${bpmResult.bpm}`);
 
 // Find optimal loop points
 const analysis = await librosaLoopAnalysis(audioBuffer);
-console.log(`Loop: ${analysis.loopStart}s - ${analysis.loopEnd}s`);
-console.log(`Musical division: ${analysis.musicalDivision} bars`);
+debugLog(`Loop: ${analysis.loopStart}s - ${analysis.loopEnd}s`);
+debugLog(`Musical division: ${analysis.musicalDivision} bars`);
 
 // Create interactive waveform editor
 const canvas = document.getElementById('waveform');
@@ -92,7 +92,7 @@ See `examples/demo.html` for a simple interactive page that detects BPM from an 
 
 ## Debugging
 
-Enable verbose logging by setting the `PLECO_DEBUG` flag or by calling `setDebug(true)` from code. In Node.js you can run:
+Enable verbose logging by setting the `PLECO_DEBUG` flag or by calling `setDebug(true)` from code. Both `setDebug` and `debugLog` are exported from `pleco-xa`. In Node.js you can run:
 
 ```bash
 PLECO_DEBUG=true node your-script.js

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export { WaveformEditor } from './classes/WaveformEditor.js';
 export { LoopPlayer } from './classes/LoopPlayer.js';
 
 // Debugging flag
-export { DEBUG_ENABLED } from './utils/debug.js';
+export { DEBUG_ENABLED, setDebug, debugLog } from './utils/debug.js';
 
 // Version info
 export const version = '1.0.1';

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,4 +1,4 @@
-let DEBUG_ENABLED = Boolean(
+export let DEBUG_ENABLED = Boolean(
   (typeof process !== 'undefined' && process.env && process.env.PLECO_DEBUG) ||
   (typeof window !== 'undefined' && window.PLECO_DEBUG)
 );
@@ -17,4 +17,8 @@ export function debugLog(...args) {
   if (DEBUG_ENABLED) {
     console.log(...args);
   }
+}
+
+export function isDebugEnabled() {
+  return DEBUG_ENABLED;
 }


### PR DESCRIPTION
## Summary
- export `debugLog` and `setDebug`
- export the debug helpers from the main module
- update README quick start snippet to use `debugLog`
- document debugging helpers

## Testing
- `npm test`