### PR TITLE
Add SEO tags & sitemap docs for Astro demo

### DIFF
--- a/examples/astro-site/README.md
+++ b/examples/astro-site/README.md
@@ -32,7 +32,24 @@ npm run build
 
 ### Sitemap Generation
 
-To generate a sitemap for better indexing, install the `@astrojs/sitemap`
-integration and define the `site` option in `astro.config.mjs`.
+To generate a sitemap for better indexing when you deploy:
 
-Deploy the `dist/` folder to your static hosting provider.
+1. Install the sitemap integration:
+   ```bash
+   npm install -D @astrojs/sitemap
+   ```
+2. Configure `astro.config.mjs` with your site URL and the integration:
+   ```javascript
+   import { defineConfig } from 'astro/config';
+   import sitemap from '@astrojs/sitemap';
+
+   export default defineConfig({
+     site: 'https://example.com', // replace with your domain
+     output: 'static',
+     integrations: [sitemap()],
+   });
+   ```
+3. Run `npm run build`. The sitemap will be generated in the `dist/` folder.
+
+Deploy the `dist/` directory to your hosting provider and your sitemap will be
+available alongside the site content.

--- a/examples/astro-site/src/pages/index.astro
+++ b/examples/astro-site/src/pages/index.astro
@@ -17,12 +17,14 @@ import { BPMDetector, PlecoAnalyzer } from '../../../astro/index.js';
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/social.png" />
+    <meta property="og:url" content="https://example.com/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Pleco Xa Astro Demo" />
     <meta
       name="twitter:description"
       content="Explore advanced BPM detection and audio analysis directly in your browser."
     />
+    <meta name="twitter:image" content="/social.png" />
     <script type="application/ld+json">
       {"@context":"https://schema.org","@type":"WebSite","name":"Pleco Xa Astro Demo","url":"https://example.com/","description":"Interactive demo showcasing Pleco Xa BPM detection and music analysis tools."}
     </script>


### PR DESCRIPTION
## Summary
- extend meta tags in index.astro for social sharing
- document how to add `@astrojs/sitemap` when deploying

## Testing
- `npm test`