### PR TITLE
docs: clarify test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ messages are suppressed unless `PLECO_DEBUG` is set.
 
 ## Testing
 
-Install dependencies with `npm ci` (or `npm install`) and then run the Jest
+Run `npm ci` to install all development dependencies before executing the Jest
 test suite:
 
 ```bash
+npm ci
 npm test
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `npm ci` should run before running `npm test`

## Testing
- `npm test`