### PR TITLE
Add debug flag for server logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,13 @@ PLECO_DEBUG=true node your-script.js
 
 In the browser, assign `window.PLECO_DEBUG = true` before loading Pleco Xa or call `setDebug(true)`. When enabled, additional information is printed to the console.
 
-Most example scripts use a `debugLog()` helper that checks this flag. Verbose
-messages are suppressed unless `PLECO_DEBUG` is set.
+Most example scripts and the sample servers use a `debugLog()` helper that
+checks this flag. Verbose messages are suppressed unless `PLECO_DEBUG` is set.
+For example, to see server logs while developing you can run:
+
+```bash
+PLECO_DEBUG=true node deploying/railway-api/server.js
+```
 
 ## Testing
 

--- a/deploying/railway-api/server.js
+++ b/deploying/railway-api/server.js
@@ -5,10 +5,18 @@ import success from './success.js';
 const app = express();
 app.use(express.json());
 
+const DEBUG_ENABLED = Boolean(process.env.PLECO_DEBUG);
+
+function debugLog(...args) {
+  if (DEBUG_ENABLED) {
+    console.log(...args);
+  }
+}
+
 app.post('/create-session', createSession);
 app.get('/success', success);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
+  debugLog(`Server listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- wrap Railway example server logging in `debugLog`
- show `PLECO_DEBUG` usage in the README

## Testing
- `npm test`