### PR TITLE
chore: add Railway Dockerfile and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ messages are suppressed unless `PLECO_DEBUG` is set.
 
 ## Testing
 
-Install dependencies with `npm ci` (or `npm install`) and then run the Jest
+Run `npm ci` to install all development dependencies before executing the Jest
 test suite:
 
 ```bash
+npm ci
 npm test
 ```
 

--- a/deploying/README.md
+++ b/deploying/README.md
@@ -42,6 +42,8 @@ These handlers are wired up by `server.js`, which starts an Express server when
 
 Run `railway up` from the same `railway-api` folder to deploy these functions.
 Railway will install the dependencies declared in `package.json` automatically.
+A `Dockerfile` is included so the service can be built and started without any
+additional configuration.
 
 ## 3. Integrate with the Paywall
 

--- a/deploying/railway-api/Dockerfile
+++ b/deploying/railway-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY . .
+CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- restore plugin-terser exports removed by mistake
- add Dockerfile so Railway can deploy Node backend
- mention Dockerfile in deployment docs

## Testing
- `npm test`