### PR TITLE
Fix terser import order

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
+import { terser } from '@rollup/plugin-terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
 
 const basePlugins = [nodeResolve()];
 


### PR DESCRIPTION
## Summary
- import `terser` as a named function before `nodeResolve`
- keep minification in both rollup outputs

## Testing
- `npm test`
- `npm run build`
