### PR TITLE
Update Railway install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,12 +336,12 @@ A minimal Stripe Checkout backend is included in the [deploying/](deploying/READ
 
 ### Nixpacks configuration
 
-Railway reads the `.nixpacks.toml` file in `deploying/railway-api/` to set up the environment. It installs Node 20 automatically and then runs `npm ci` followed by `npm start`.
+Railway reads the `.nixpacks.toml` file in `deploying/railway-api/` to set up the environment. It installs Node 20 automatically and then runs `npm install` followed by `npm start`.
 
 For local testing you can run the same commands without Docker:
 
 ```bash
-npm ci
+npm install
 npm start
 ```
 

--- a/deploying/README.md
+++ b/deploying/README.md
@@ -42,8 +42,10 @@ These handlers are wired up by `server.js`, which starts an Express server when
 
 Run `railway up` from the same `railway-api` folder to deploy these functions.
 Railway will install the dependencies declared in `package.json` automatically.
-A `Dockerfile` is included so the service can be built and started without any
-additional configuration.
+The `.nixpacks.toml` runs `npm install` to fetch dependencies during the build.
+Add a `package-lock.json` and change this step to `npm ci` if you want
+fully reproducible installs.
+
 
 ## 3. Integrate with the Paywall
 

--- a/deploying/railway-api/.nixpacks.toml
+++ b/deploying/railway-api/.nixpacks.toml
@@ -2,7 +2,7 @@
 nixPkgs = ["nodejs-20_x"]
 
 [phases.install]
-cmds = ["npm ci"]
+cmds = ["npm install"]
 
 [start]
 cmd = "npm start"


### PR DESCRIPTION
## Summary
- use `npm install` in the Railway nixpacks config
- document the updated install command

## Testing
- `npm test` *(fails: Cannot find module 'jest')*