### PR TITLE
Clarify Railway install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ A minimal Stripe Checkout backend is included in the [deploying/](deploying/READ
 
 ### Nixpacks configuration
 
-Railway reads the `.nixpacks.toml` file in `deploying/railway-api/` to set up the environment. It installs Node 20 automatically and then runs `npm ci` followed by `npm start`.
+Railway reads the `.nixpacks.toml` file in `deploying/railway-api/` to set up the environment. It installs Node 20 automatically and then runs `npm ci` followed by `npm start`. Using `npm ci` ensures the installed packages exactly match the `package-lock.json` for reproducible builds.
 
 For local testing you can run the same commands without Docker:
 

--- a/deploying/README.md
+++ b/deploying/README.md
@@ -42,7 +42,7 @@ These handlers are wired up by `server.js`, which starts an Express server when
 
 Run `railway up` from the same `railway-api` folder to deploy these functions.
 Railway will install the dependencies declared in `package.json` automatically.
-The build uses `.nixpacks.toml`, which pins Node 20 and runs `npm ci`. Without a `package-lock.json` the build will fail. Either generate a lockfile or change the install command in `.nixpacks.toml` to `npm install` if you prefer not to use one.
+The build uses `.nixpacks.toml`, which pins Node 20 and runs `npm ci` for deterministic dependency installs. Without a `package-lock.json` the build will fail. Either generate a lockfile or change the install command in `.nixpacks.toml` to `npm install` if you prefer not to use one.
 
 
 

--- a/deploying/railway-api/.nixpacks.toml
+++ b/deploying/railway-api/.nixpacks.toml
@@ -2,6 +2,7 @@
 nixPkgs = ["nodejs-20_x"]
 
 [phases.install]
+# Install dependencies using the lockfile for reproducible builds
 cmds = ["npm ci"]
 
 [phases.build]


### PR DESCRIPTION
## Summary
- document that Railway uses `npm ci`
- add comment in `.nixpacks.toml`
- explain deterministic installs in deploying docs

## Testing
- `npm test`