### PR TITLE
Fix audio MIME types

### DIFF
--- a/src/scripts/api/upload-audio.js
+++ b/src/scripts/api/upload-audio.js
@@ -19,12 +19,12 @@ export async function POST({ request }) {
 
     // Validate file type
     const allowedTypes = [
-      'assets/audio/mpeg',
-      'assets/audio/wav',
-      'assets/audio/mp4',
-      'assets/audio/m4a',
-      'assets/audio/aiff',
-      'assets/audio/x-aiff',
+      'audio/mpeg',
+      'audio/wav',
+      'audio/mp4',
+      'audio/m4a',
+      'audio/aiff',
+      'audio/x-aiff',
     ]
     if (!allowedTypes.includes(audioFile.type)) {
       return new Response(JSON.stringify({ error: 'Invalid file type' }), {

--- a/src/scripts/audio-utils.js
+++ b/src/scripts/audio-utils.js
@@ -104,7 +104,7 @@ export function exportBufferAsWav(buffer) {
     }
   }
 
-  return new Blob([view], { type: 'assets/audio/wav' })
+  return new Blob([view], { type: 'audio/wav' })
 }
 
 /**

--- a/src/scripts/xa-file.js
+++ b/src/scripts/xa-file.js
@@ -219,7 +219,7 @@ export async function example(
 
     const response = await fetch(baseUrl + filename, {
       headers: {
-        Accept: 'assets/audio/*',
+        Accept: 'audio/*',
       },
     })
 
@@ -391,7 +391,7 @@ export function saveAudio(
   const wavData = _encodeWAV(audioData, sampleRate)
 
   // Create download link
-  const blob = new Blob([wavData], { type: 'assets/audio/wav' })
+  const blob = new Blob([wavData], { type: 'audio/wav' })
   const url = URL.createObjectURL(blob)
 
   const link = document.createElement('a')


### PR DESCRIPTION
## Summary
- use standard MIME types when validating uploaded audio
- update Accept header for audio downloads
- fix Blob creation types

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68464ebf2af483259c49d7976375ed11