### PR TITLE
Switch README tests to Vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ PLECO_DEBUG=true node deploying/railway-api/server.js
 
 ## Testing
 
-Run `npm ci` to install all development dependencies before executing the Jest
+Run `npm ci` to install all development dependencies before executing the Vitest
 test suite:
 
 ```bash
@@ -124,8 +124,7 @@ npm ci
 npm test
 ```
 
-This command executes all tests configured in `jest.config.cjs` using Node's
-`--experimental-vm-modules` flag so Jest can run ES modules.
+This command runs all tests configured in `vitest.config.js`.
 
 ## Astro Integration
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "start": "astro preview --port $PORT --host"
+    "start": "astro preview --port $PORT --host",
+    "test": "vitest run"
   },
   "dependencies": {
     "@astrojs/node": "^9.2.2",


### PR DESCRIPTION
## Summary
- add `test` script to package.json for Vitest
- update README testing instructions to use Vitest and mention `vitest.config.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464ecb491883258be87d2846980490