### PR TITLE
Fix vitest config

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.{js,ts,mjs}'],
-    setupFiles: ['./tests/setup.js']
+    include: ['tests/**/*.test.{js,ts,mjs}']
   }
 })


### PR DESCRIPTION
## Summary
- remove reference to missing test setup file

## Testing
- `npx vitest run` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68464ecfa3988325b8c38a42501f9355