### PR TITLE
Add mp3 support warning

### DIFF
--- a/src/scripts/audio-analysis.js
+++ b/src/scripts/audio-analysis.js
@@ -27,6 +27,7 @@ import { chroma_stft, enhance_chroma } from './xa-chroma.js'
 import { fastLoopAnalysis } from './xa-loop.js'
 import { findPreciseLoop } from './xa-precise-loop.js'
 import { findMusicalLoop, findDownbeatPhase } from './xa-downbeat.js'
+import { warnIfNoMp3Support } from './xa-util.js'
 
 // Audio utilities
 import {
@@ -73,6 +74,7 @@ function showError(message) {
 // ===== INITIALIZATION =====
 document.addEventListener('DOMContentLoaded', () => {
   console.log('🎵 Pleco-XA Audio Analysis Engine loading...')
+  warnIfNoMp3Support()
   try {
     setupEventListeners()
     console.log('✅ Event listeners initialized')

--- a/src/scripts/xa-util.js
+++ b/src/scripts/xa-util.js
@@ -681,3 +681,37 @@ export function linspace(start, stop, num) {
   const step = (stop - start) / (num - 1)
   return Array.from({ length: num }, (_, i) => start + step * i)
 }
+
+/**
+ * Check MP3 playback support and optionally show a warning banner.
+ *
+ * @returns {string} The result of canPlayType for 'audio/mp3'.
+ */
+export function warnIfNoMp3Support() {
+  const canPlay =
+    typeof Audio !== 'undefined' ? new Audio().canPlayType('audio/mp3') : ''
+  if (typeof document !== 'undefined' && typeof Audio !== 'undefined' && !canPlay) {
+    let banner = document.getElementById('mp3Warning')
+    if (!banner) {
+      banner = document.createElement('div')
+      banner.id = 'mp3Warning'
+      banner.style.backgroundColor = '#ffc107'
+      banner.style.color = '#000'
+      banner.style.padding = '10px'
+      banner.style.margin = '10px 0'
+      banner.style.border = '1px solid #ffa000'
+      banner.style.borderRadius = '4px'
+      banner.style.textAlign = 'center'
+      banner.style.display = 'none'
+      document.body.prepend(banner)
+    }
+
+    banner.textContent = 'Warning: your browser cannot play MP3 audio.'
+    banner.style.display = 'block'
+
+    setTimeout(() => {
+      banner.style.display = 'none'
+    }, 5000)
+  }
+  return canPlay
+}


### PR DESCRIPTION
## Summary
- add `warnIfNoMp3Support` helper in `xa-util`
- warn about missing mp3 support on page init

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68464f099c1083259a4d00302e410ad7