### PR TITLE
Add display reset on track load

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -406,6 +406,7 @@ const {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (file) {
         try {
+          clearAnalysisDisplay();
           updateTrackInfo(file.name, 'Loading...');
           
           // Load and analyze the file
@@ -605,7 +606,8 @@ const {
         btn.disabled = true;
         btn.style.opacity = '0.5';
       });
-      
+
+      clearAnalysisDisplay();
       updateTrackInfo(name, 'Loading...');
       document.getElementById('bpmValue').textContent = '...';
       
@@ -864,6 +866,21 @@ const {
     }
     
     document.getElementById('loopInfo').textContent = loopText;
+  }
+
+  // Clear BPM, waveform canvas and loop markers
+  function clearAnalysisDisplay() {
+    const bpmEl = document.getElementById('bpmValue');
+    if (bpmEl) bpmEl.textContent = '--';
+
+    const canvas = document.getElementById('waveformCanvas');
+    if (canvas) {
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
+
+    document.getElementById('loopInfo').textContent = 'Full Track';
+    audioProcessor?.setLoopPoints(0, 1);
   }
   
   // Show error message


### PR DESCRIPTION
## Summary
- clear BPM readout, waveform canvas, and loop markers via `clearAnalysisDisplay`
- invoke the new function whenever a track is loaded from file or sample

## Testing
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68464f2803448325b189f1848f3a36ba