### PR TITLE
Enable draggable loop markers in waveform

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -368,6 +368,8 @@ const {
   let currentAudioBuffer = null;
   let isPlaying = false;
   let currentBeats = []; // Store beat times from BPM detection
+  let isDraggingMarker = false;
+  let dragMarker = null; // 'start' or 'end'
   
   // Initialize audio processor when DOM is ready
   document.addEventListener('DOMContentLoaded', () => {
@@ -589,12 +591,64 @@ const {
           startWaveformAnimation();
         }
         
-        showError('Loop section reversed successfully');
+      showError('Loop section reversed successfully');
       } catch (error) {
         console.error('❌ Error reversing loop:', error);
         showError(`Failed to reverse loop: ${error.message}`);
       }
     });
+
+    // ===== Waveform marker drag =====
+    const canvas = document.getElementById('waveformCanvas');
+    if (canvas) {
+      canvas.addEventListener('mousedown', (e) => {
+        if (!currentAudioBuffer || !audioProcessor) return;
+
+        const rect = canvas.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const { start, end } = audioProcessor.getLoopPoints();
+        const startX = start * canvas.width;
+        const endX = end * canvas.width;
+
+        if (Math.abs(x - startX) < 10) {
+          isDraggingMarker = true;
+          dragMarker = 'start';
+        } else if (Math.abs(x - endX) < 10) {
+          isDraggingMarker = true;
+          dragMarker = 'end';
+        }
+      });
+
+      canvas.addEventListener('mousemove', (e) => {
+        if (!isDraggingMarker || !currentAudioBuffer || !audioProcessor) return;
+
+        const rect = canvas.getBoundingClientRect();
+        let pos = (e.clientX - rect.left) / canvas.width;
+        pos = Math.min(1, Math.max(0, pos));
+
+        let { start, end } = audioProcessor.getLoopPoints();
+        if (dragMarker === 'start') {
+          start = Math.min(pos, end - 0.01);
+        } else if (dragMarker === 'end') {
+          end = Math.max(pos, start + 0.01);
+        }
+
+        audioProcessor.setLoopPoints(start, end);
+        updateLoopInfo({ start, end });
+
+        drawWaveform(currentAudioBuffer, 'waveformCanvas', { start, end });
+      });
+
+      canvas.addEventListener('mouseup', () => {
+        isDraggingMarker = false;
+        dragMarker = null;
+      });
+
+      canvas.addEventListener('mouseleave', () => {
+        isDraggingMarker = false;
+        dragMarker = null;
+      });
+    }
   }
   
   // Load a sample audio file


### PR DESCRIPTION
## Summary
- allow loop markers to be dragged directly on the waveform
- show loop marker drag state in AudioAnalyzer

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68464f30c55c83258e1e299e84eac846