### PR TITLE
Improve file decode error handling

### DIFF
--- a/src/components/BPMDetector.astro
+++ b/src/components/BPMDetector.astro
@@ -56,6 +56,10 @@ const { showConfidence = true, autoDetect = true, threshold = 0.3, class: classN
     transition: background 0.2s;
   }
 
+  .bpm-upload label.error {
+    background: #b00020;
+  }
+
   .bpm-upload label:hover {
     background: #0052a3;
   }
@@ -99,7 +103,26 @@ const { showConfidence = true, autoDetect = true, threshold = 0.3, class: classN
             window.AudioContext || (window as any).webkitAudioContext
           const audioContext = new AudioContextConstructor()
           const arrayBuffer = await file.arrayBuffer()
-          const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+          let audioBuffer
+          try {
+            audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+          } catch (decodeError) {
+            console.error('Audio decoding failed:', decodeError)
+            const btn = fileInput.nextElementSibling
+            if (btn) {
+              btn.classList.add('error')
+              btn.setAttribute('title', 'Unsupported format')
+              setTimeout(() => {
+                btn.classList.remove('error')
+                btn.removeAttribute('title')
+              }, 5000)
+            }
+            bpmValue.textContent = 'Error'
+            if (bpmConfidence) {
+              bpmConfidence.textContent = 'Detection failed'
+            }
+            return
+          }
 
           const result = fastBPMDetect(audioBuffer, { minBPM: 60, maxBPM: 180 })
 

--- a/src/components/LoopPlayer.astro
+++ b/src/components/LoopPlayer.astro
@@ -42,6 +42,10 @@ const { autoPlay = false, class: className = '' } = Astro.props
     margin-bottom: 10px;
   }
 
+  .loop-upload label.error {
+    background: #b00020;
+  }
+
   .loop-controls {
     display: flex;
     gap: 10px;
@@ -109,7 +113,16 @@ const { autoPlay = false, class: className = '' } = Astro.props
           } catch (decodeError) {
             console.error('Audio decoding failed:', decodeError);
             elements.fileInput.disabled = false;
-            elements.fileInput.nextElementSibling.textContent = "Load Loop (Error - Try Again)";
+            const btn = elements.fileInput.nextElementSibling;
+            if (btn) {
+              btn.classList.add('error');
+              btn.setAttribute('title', 'Unsupported format');
+              btn.textContent = 'Load Loop';
+              setTimeout(() => {
+                btn.classList.remove('error');
+                btn.removeAttribute('title');
+              }, 5000);
+            }
           }
         };
         

--- a/src/components/PlecoAnalyzer.astro
+++ b/src/components/PlecoAnalyzer.astro
@@ -106,6 +106,10 @@ const {
     transition: background 0.2s;
   }
 
+  .pleco-upload label.error {
+    background: #b00020;
+  }
+
   .pleco-upload label:hover {
     background: #0052a3;
   }
@@ -184,7 +188,22 @@ const {
             window.AudioContext || (window as any).webkitAudioContext
           const audioContext = new AudioContextConstructor()
           const arrayBuffer = await file.arrayBuffer()
-          const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+          let audioBuffer
+          try {
+            audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+          } catch (decodeError) {
+            console.error('Audio decoding failed:', decodeError)
+            const btn = fileInput.nextElementSibling
+            if (btn) {
+              btn.classList.add('error')
+              btn.setAttribute('title', 'Unsupported format')
+              setTimeout(() => {
+                btn.classList.remove('error')
+                btn.removeAttribute('title')
+              }, 5000)
+            }
+            return
+          }
 
           // Analyze with Pleco Xa using fast functions
           let bpmResult;

--- a/src/components/WaveformEditor.astro
+++ b/src/components/WaveformEditor.astro
@@ -26,7 +26,22 @@
     async function initAudio(file) {
       try {
         const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
-        const audioBuffer = await audioContext.decodeAudioData(await file.arrayBuffer())
+        let audioBuffer
+        try {
+          audioBuffer = await audioContext.decodeAudioData(await file.arrayBuffer())
+        } catch (decodeError) {
+          console.error('Audio decoding failed:', decodeError)
+          const btn = elements.fileInput?.nextElementSibling
+          if (btn) {
+            btn.classList.add('error')
+            btn.setAttribute('title', 'Unsupported format')
+            setTimeout(() => {
+              btn.classList.remove('error')
+              btn.removeAttribute('title')
+            }, 5000)
+          }
+          return
+        }
         
         const loopStart = 0
         const loopEnd = audioBuffer.duration


### PR DESCRIPTION
## Summary
- add `.error` style for upload buttons
- highlight upload button when audio decode fails
- show unsupported format tooltip and clear it after 5s

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden when trying to install jest)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f3478ec8325a3739cb2512b2a0e