### PR TITLE
Add Tailwind theme toggle and responsive grid

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -150,7 +150,7 @@ const {
 
   .analysis-display {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: 1fr minmax(0, 2fr) 1fr;
     gap: 2rem;
     margin-top: 2rem;
   }
@@ -337,7 +337,7 @@ const {
 
   @media (max-width: 768px) {
     .analysis-display {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
       gap: 1rem;
     }
 

--- a/src/components/MainLayout.astro
+++ b/src/components/MainLayout.astro
@@ -9,8 +9,30 @@ const { title, description } = Astro.props
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <title>{title}</title>
+    <!-- Tailwind via CDN with dark mode using data-theme attribute -->
+    <script>
+      tailwind.config = { darkMode: ['class', '[data-theme="dark"]'] };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      const storedTheme =
+        typeof localStorage !== 'undefined' && localStorage.getItem('theme');
+      const prefersDark =
+        typeof window !== 'undefined' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = storedTheme || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+      window.toggleTheme = () => {
+        const current = document.documentElement.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        document.documentElement.classList.toggle('dark', next === 'dark');
+        if (typeof localStorage !== 'undefined') localStorage.setItem('theme', next);
+      };
+    </script>
     <!-- Additional meta tags or styles can be added here -->
-  </head>  
+  </head>
   <body>
     <slot />
     <!-- Common footer or navigation can be added here -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -75,6 +75,9 @@ const description = 'Browser-native audio analysis library for intelligent loop 
     <div class="header">
       <h1 class="main-title">Pleco-XA</h1>
       <p>Professional Audio Analysis Engine</p>
+      <button onclick="toggleTheme()" class="mt-4 px-3 py-1 rounded bg-gray-700 text-white hover:bg-gray-600">
+        Toggle Theme
+      </button>
     </div>
 
     <!-- Use the new AudioAnalyzer component -->


### PR DESCRIPTION
## Summary
- add Tailwind via CDN
- persist theme preference in localStorage and provide toggle
- make analysis grid responsive with `minmax()`

## Testing
- `npx vitest --run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68464f37581c832583f8f83334e055da