### PR TITLE
Improve accessibility for BPM updates

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -45,7 +45,7 @@ const {
 
   <div class="analysis-display">
     <div class="bpm-display">
-      <div class="bpm-value" id="bpmValue">--</div>
+      <div class="bpm-value" id="bpmValue" aria-live="polite" tabindex="0">--</div>
       <div class="bpm-label">BPM</div>
 
       <div class="timeline-container">

--- a/src/components/BPMDetector.astro
+++ b/src/components/BPMDetector.astro
@@ -13,11 +13,11 @@ const { showConfidence = true, autoDetect = true, threshold = 0.3, class: classN
 <div class={`pleco-bpm-detector ${className}`}>
   <div class="bpm-upload">
     <input type="file" id="bpmFileInput" accept="audio/*" />
-    <label for="bpmFileInput">Detect BPM</label>
+    <label for="bpmFileInput" tabindex="0">Detect BPM</label>
   </div>
 
   <div class="bpm-display" id="bpmDisplay">
-    <div class="bpm-value" id="bpmValue">-- BPM</div>
+    <div class="bpm-value" id="bpmValue" aria-live="polite" tabindex="0">-- BPM</div>
     {
       showConfidence && (
         <div class="bpm-confidence" id="bpmConfidence">
@@ -84,6 +84,16 @@ const { showConfidence = true, autoDetect = true, threshold = 0.3, class: classN
     const fileInput = document.getElementById('bpmFileInput')
     const bpmValue = document.getElementById('bpmValue')
     const bpmConfidence = document.getElementById('bpmConfidence')
+    const uploadLabel = document.querySelector('label[for="bpmFileInput"]')
+
+    if (uploadLabel) {
+      uploadLabel.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          fileInput?.click()
+        }
+      })
+    }
 
     if (fileInput) {
       fileInput.addEventListener('change', async (e) => {

--- a/src/components/LoopPlayer.astro
+++ b/src/components/LoopPlayer.astro
@@ -11,7 +11,7 @@ const { autoPlay = false, class: className = '' } = Astro.props
 <div class={`pleco-loop-player ${className}`} data-autoplay={autoPlay.toString()}>
   <div class="loop-upload">
     <input type="file" id="loopFileInput" accept="audio/*" />
-    <label for="loopFileInput">Load Loop</label>
+    <label for="loopFileInput" tabindex="0">Load Loop</label>
   </div>
 
   <div class="loop-controls" id="loopControls" style="display: none;">
@@ -72,6 +72,16 @@ const { autoPlay = false, class: className = '' } = Astro.props
       controls: document.getElementById('loopControls') as HTMLDivElement,
       playBtn: document.getElementById('playLoop') as HTMLButtonElement,
       stopBtn: document.getElementById('stopLoop') as HTMLButtonElement
+    }
+    const uploadLabel = document.querySelector('label[for="loopFileInput"]')
+
+    if (uploadLabel) {
+      uploadLabel.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          elements.fileInput?.click()
+        }
+      })
     }
     
     const autoPlay = (document.querySelector('.pleco-loop-player') as HTMLElement)?.dataset.autoplay === 'true'

--- a/src/components/PlecoAnalyzer.astro
+++ b/src/components/PlecoAnalyzer.astro
@@ -28,7 +28,7 @@ const {
     allowUpload && (
       <div class="pleco-upload">
         <input type="file" id="plecoFileInput" accept="assets/audio/*" />
-        <label for="plecoFileInput">Choose Audio File</label>
+        <label for="plecoFileInput" tabindex="0">Choose Audio File</label>
       </div>
     )
   }
@@ -38,7 +38,7 @@ const {
       showBPM && (
         <div class="pleco-bpm">
           <h3>BPM Detection</h3>
-          <div class="bpm-value" id="bpmValue">
+          <div class="bpm-value" id="bpmValue" aria-live="polite" tabindex="0">
             --
           </div>
           <div class="bpm-confidence" id="bpmConfidence">
@@ -171,6 +171,16 @@ const {
     const spectralInfo = document.getElementById('spectralInfo')
     const playBtn = document.getElementById('playLoop')
     const stopBtn = document.getElementById('stopLoop')
+    const uploadLabel = document.querySelector('label[for="plecoFileInput"]')
+
+    if (uploadLabel) {
+      uploadLabel.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          fileInput?.click()
+        }
+      })
+    }
 
     if (fileInput) {
       fileInput.addEventListener('change', async (e) => {


### PR DESCRIPTION
## Summary
- make BPM value updates polite and focusable
- add keyboard support for upload labels
- make loop player label focusable

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68464f3ac0b08325b94d6fa0a900a98a