### PR TITLE
Add web worker for audio analysis

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -349,8 +349,8 @@ const {
 
 <script>
   // Import core functionality
-  import { 
-    initAudioProcessor, 
+  import {
+    initAudioProcessor,
     loadAudioFile,
     drawWaveform
   } from '../scripts/xa-audio-core.js';
@@ -361,6 +361,9 @@ const {
   // Import analysis modules
   import { detectBPM, detectBPMWindow } from '../scripts/analysis/BPMDetector.js';
   import { findLoop, manipulateLoop } from '../scripts/xa-loop-detection.js';
+
+  // Worker for heavy analysis
+  let analysisWorker = null;
   
   // Initialize state
   let audioContext;
@@ -368,12 +371,31 @@ const {
   let currentAudioBuffer = null;
   let isPlaying = false;
   let currentBeats = []; // Store beat times from BPM detection
+  let currentTrackName = '';
   
   // Initialize audio processor when DOM is ready
   document.addEventListener('DOMContentLoaded', () => {
     try {
       // Initialize the audio processor
       audioProcessor = initAudioProcessor();
+
+      // Create analysis worker
+      analysisWorker = new Worker(new URL('../core/analysisWorker.js', import.meta.url), { type: 'module' });
+      analysisWorker.onmessage = (e) => {
+        const { bpm, loopPoints, progress } = e.data;
+        if (typeof progress === 'number') {
+          updateTrackInfo(currentTrackName || '', `Analyzing: ${Math.round(progress * 100)}%`);
+        }
+        if (typeof bpm === 'number') {
+          window.currentBPM = bpm;
+          document.getElementById('bpmValue').textContent = bpm.toFixed(1);
+        }
+        if (loopPoints && currentAudioBuffer) {
+          audioProcessor.setLoopPoints(loopPoints.start, loopPoints.end);
+          updateLoopInfo(loopPoints);
+          drawWaveform(currentAudioBuffer, 'waveformCanvas', loopPoints);
+        }
+      };
       
       // Set up event listeners
       setupEventListeners();
@@ -407,11 +429,15 @@ const {
       if (file) {
         try {
           updateTrackInfo(file.name, 'Loading...');
-          
+          currentTrackName = file.name;
+
           // Load and analyze the file
           const result = await loadAudioFile(file);
           currentAudioBuffer = result.audioBuffer;
           audioContext = result.audioContext;
+          if (analysisWorker && result.arrayBuffer) {
+            analysisWorker.postMessage(result.arrayBuffer);
+          }
           
           // Update UI with file info
           updateTrackInfo(
@@ -422,7 +448,7 @@ const {
           document.getElementById('audioFormat').textContent =
             `${currentAudioBuffer.sampleRate}Hz / ${currentAudioBuffer.numberOfChannels}ch`;
           
-          // Analyze the audio (BPM detection)
+          // Fallback BPM detection if worker fails
           const bpmResult = await detectBPM(currentAudioBuffer);
           document.getElementById('bpmValue').textContent = bpmResult.bpm.toFixed(1);
           
@@ -613,6 +639,10 @@ const {
       const result = await loadAudioFile(url);
       currentAudioBuffer = result.audioBuffer;
       audioContext = result.audioContext;
+      currentTrackName = name;
+      if (analysisWorker && result.arrayBuffer) {
+        analysisWorker.postMessage(result.arrayBuffer);
+      }
       
       // Update UI with file info immediately
       updateTrackInfo(

--- a/src/core/analysisWorker.js
+++ b/src/core/analysisWorker.js
@@ -1,0 +1,29 @@
+import { fastBPMDetect } from '../scripts/analysis/BPMDetector.js';
+import { fastLoopAnalysis } from '../scripts/xa-loop.js';
+
+self.onmessage = async (event) => {
+  const arrayBuffer = event.data;
+  if (!(arrayBuffer instanceof ArrayBuffer)) return;
+
+  try {
+    self.postMessage({ progress: 0 });
+
+    const ctx = new OfflineAudioContext(1, 1, 44100);
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+    self.postMessage({ progress: 0.5 });
+
+    const bpmResult = fastBPMDetect(audioBuffer);
+    self.postMessage({ progress: 0.75, bpm: bpmResult });
+
+    let loop = null;
+    try {
+      loop = await fastLoopAnalysis(audioBuffer);
+    } catch (err) {
+      // ignore loop errors
+    }
+
+    self.postMessage({ bpm: bpmResult, loopPoints: loop, progress: 1 });
+  } catch (err) {
+    self.postMessage({ error: err.message });
+  }
+};

--- a/src/scripts/xa-audio-core.js
+++ b/src/scripts/xa-audio-core.js
@@ -175,6 +175,7 @@ export async function loadAudioFile(source) {
   });
   
   let audioBuffer;
+  let arrayBuffer;
   
   // Handle URL string
   if (typeof source === 'string') {
@@ -184,7 +185,8 @@ export async function loadAudioFile(source) {
     if (audioBufferCache.has(url)) {
       return {
         audioBuffer: audioBufferCache.get(url),
-        audioContext
+        audioContext,
+        arrayBuffer: null
       };
     }
     
@@ -195,16 +197,16 @@ export async function loadAudioFile(source) {
       throw new Error(`Failed to load audio: HTTP ${response.status}`);
     }
     
-    const arrayBuffer = await response.arrayBuffer();
-    audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    arrayBuffer = await response.arrayBuffer();
+    audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
     
     // Cache the result
     audioBufferCache.set(url, audioBuffer);
   } 
   // Handle File object
   else if (source instanceof File) {
-    const arrayBuffer = await source.arrayBuffer();
-    audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    arrayBuffer = await source.arrayBuffer();
+    audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
   }
   else {
     throw new Error('Invalid source type');
@@ -212,7 +214,8 @@ export async function loadAudioFile(source) {
   
   return {
     audioBuffer,
-    audioContext
+    audioContext,
+    arrayBuffer
   };
 }
 


### PR DESCRIPTION
## Summary
- add `src/core/analysisWorker.js` for BPM and loop detection
- extend `loadAudioFile` to return `arrayBuffer`
- use the new worker in `AudioAnalyzer.astro` for async analysis

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68464f5505a88325b603e9fbe2c186fa