### PR TITLE
Add signature demo loop feature

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -9,6 +9,8 @@ interface Props {
   class?: string;
 }
 
+import SignatureDemoButton from './SignatureDemoButton.astro';
+
 const { 
   title = 'Audio Analysis', 
   showControls = true,
@@ -90,6 +92,7 @@ const {
         <div class="card-value" id="audioFormat">--</div>
         <p class="card-description">Decoded audio information</p>
       </div>
+      <SignatureDemoButton audioBuffer={currentAudioBuffer} applyLoop={applyLoop} />
     </div>
   </div>
 
@@ -988,5 +991,22 @@ const {
     }
     
     requestAnimationFrame(animateTimeline);
+  }
+
+  function applyLoop(buf, loop, op) {
+    if (!buf || !loop || !audioProcessor) return;
+    currentAudioBuffer = buf;
+    const start = loop.startSample / buf.length;
+    const end = loop.endSample / buf.length;
+    audioProcessor.setLoopPoints(start, end);
+    updateLoopInfo({ start, end });
+    drawWaveform(currentAudioBuffer, 'waveformCanvas', { start, end });
+    updateTrackInfo(currentTrackName || '', op);
+    if (isPlaying) {
+      audioProcessor.stop();
+      audioProcessor.play(currentAudioBuffer).catch(() => {});
+      startTimelineAnimation();
+      startWaveformAnimation();
+    }
   }
 </script>

--- a/src/components/SignatureDemoButton.astro
+++ b/src/components/SignatureDemoButton.astro
@@ -1,0 +1,18 @@
+---
+import { signatureDemo } from '../core/index.js';
+const { audioBuffer, applyLoop } = Astro.props;
+
+async function runDemo() {
+  const steps = signatureDemo(audioBuffer);
+  for (const { fn, op } of steps) {
+    const { buffer, loop } = fn();
+    applyLoop(buffer, loop, op);
+    await new Promise(r => setTimeout(r, 400));
+  }
+}
+---
+<button class="sig-demo" on:click={runDemo}>🚀 Signature Demo</button>
+
+<style>
+.sig-demo { margin-top: .5rem; padding: .4rem .8rem; background: var(--accent); }
+</style>

--- a/src/core/demoSequences.js
+++ b/src/core/demoSequences.js
@@ -1,0 +1,118 @@
+import {
+  halfLoop,
+  doubleLoop,
+  moveForward,
+  reverseBufferSection,
+  detectLoop,
+} from './index.js';
+
+export function signatureDemo(buffer) {
+  const steps = [];
+  let loop = detectLoop(buffer);
+
+  const push = (op, mutator) => {
+    steps.push({
+      op,
+      fn: () => {
+        mutator();
+        return { buffer, loop, op };
+      },
+    });
+  };
+
+  while ((loop.endSample - loop.startSample) / buffer.sampleRate > 0.1) {
+    push('half', () => {
+      loop = halfLoop(loop);
+    });
+  }
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+
+  while (loop.startSample !== 0 || loop.endSample !== buffer.length) {
+    push('double', () => {
+      loop = doubleLoop(loop, buffer.length);
+    });
+    push('reverse', () => {
+      buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+    });
+  }
+
+  const repeatHalfDoubleReverse = () => {
+    while ((loop.endSample - loop.startSample) / buffer.sampleRate > 0.1) {
+      push('half', () => {
+        loop = halfLoop(loop);
+      });
+    }
+    while (loop.startSample !== 0 || loop.endSample !== buffer.length) {
+      push('double', () => {
+        loop = doubleLoop(loop, buffer.length);
+      });
+      push('reverse', () => {
+        buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+      });
+    }
+  };
+  repeatHalfDoubleReverse();
+
+  while ((loop.endSample - loop.startSample) / buffer.sampleRate > 0.1) {
+    push('half', () => {
+      loop = halfLoop(loop);
+    });
+  }
+  while (loop.startSample !== 0 || loop.endSample !== buffer.length) {
+    push('double', () => {
+      loop = doubleLoop(loop, buffer.length);
+    });
+    push('double', () => {
+      loop = doubleLoop(loop, buffer.length);
+    });
+    push('reverse', () => {
+      buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+    });
+  }
+
+  while ((loop.endSample - loop.startSample) / buffer.sampleRate > 0.1) {
+    push('half', () => {
+      loop = halfLoop(loop);
+    });
+  }
+  const mf = (n) => () => {
+    loop = moveForward(loop, n, buffer.length);
+  };
+
+  push('move×3', mf(3));
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+  push('move×2', mf(2));
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+  push('move×1', mf(1));
+  push('double', () => {
+    loop = doubleLoop(loop, buffer.length);
+  });
+  push('double', () => {
+    loop = doubleLoop(loop, buffer.length);
+  });
+  push('double', () => {
+    loop = doubleLoop(loop, buffer.length);
+  });
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+  push('move×2', mf(2));
+  push('double', () => {
+    loop = doubleLoop(loop, buffer.length);
+  });
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+  push('move×1', mf(1));
+  push('reverse', () => {
+    buffer = reverseBufferSection(buffer, loop.startSample, loop.endSample);
+  });
+
+  return steps;
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,8 @@
+export { signatureDemo } from './demoSequences.js';
+export {
+  detectLoop,
+  halfLoop,
+  doubleLoop,
+  moveForward,
+  reverseBufferSection,
+} from './loopHelpers.js';

--- a/src/core/loopHelpers.js
+++ b/src/core/loopHelpers.js
@@ -1,0 +1,36 @@
+export function detectLoop(buffer) {
+  return { startSample: 0, endSample: buffer.length };
+}
+
+export function halfLoop(loop) {
+  const mid = loop.startSample + Math.floor((loop.endSample - loop.startSample) / 2);
+  return { startSample: loop.startSample, endSample: mid };
+}
+
+export function doubleLoop(loop, maxSamples) {
+  const len = loop.endSample - loop.startSample;
+  const end = Math.min(loop.endSample + len, maxSamples);
+  return { startSample: loop.startSample, endSample: end };
+}
+
+export function moveForward(loop, steps, maxSamples) {
+  const len = loop.endSample - loop.startSample;
+  const start = Math.min(loop.startSample + steps, maxSamples - len);
+  return { startSample: start, endSample: start + len };
+}
+
+export function reverseBufferSection(buffer, start, end) {
+  for (let c = 0; c < buffer.numberOfChannels; c++) {
+    const data = buffer.getChannelData(c);
+    let i = 0;
+    let j = end - start - 1;
+    while (i < j) {
+      const a = data[start + i];
+      data[start + i] = data[start + j];
+      data[start + j] = a;
+      i++;
+      j--;
+    }
+  }
+  return buffer;
+}

--- a/tests/signature-demo.test.js
+++ b/tests/signature-demo.test.js
@@ -1,0 +1,11 @@
+import { signatureDemo } from '../src/core/index.js';
+import { AudioContext } from 'web-audio-test-api';
+
+describe('signatureDemo', () => {
+  it('returns expected number of steps', () => {
+    const ctx = new AudioContext({ sampleRate: 44100 });
+    const buffer = ctx.createBuffer(1, 44100, 44100);
+    const steps = signatureDemo(buffer);
+    expect(steps).toHaveLength(54);
+  });
+});


### PR DESCRIPTION
## Summary
- implement signature demo generator in `src/core`
- provide loop helper utilities and index re-export
- add UI button for signature demo and hook up to AudioAnalyzer
- expose applyLoop UI function
- add vitest test for new demo sequence

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465bc9633483259fdf6f1622d15f78