### PR TITLE
Update RandomizerButton props usage

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -7,10 +7,7 @@ interface Props {
   showControls?: boolean;
   class?: string;
 }
-import RandomizerButton from './RandomizerButton.astro';
-
 import SignatureDemoButton from './SignatureDemoButton.astro';
-
 import RandomizerButton from './RandomizerButton.astro';
 
 const { 
@@ -81,7 +78,7 @@ const {
         <h4 class="card-title">Track Info</h4>
         <div class="card-value" id="trackName">No track loaded</div>
         <p class="card-description" id="trackStatus">Load a sample to begin</p>
-        <RandomizerButton audioBufferVar="currentAudioBuffer" ctxVar="audioContext" applyLoopVar="applyLoop" />
+        <RandomizerButton audioBuffer={currentAudioBuffer} ctx={audioContext} applyLoop={applyLoop} />
       </div>
 
       <div class="analysis-card">

--- a/src/components/RandomizerButton.astro
+++ b/src/components/RandomizerButton.astro
@@ -1,27 +1,25 @@
 interface Props {
-  audioBufferVar?: string
-  ctxVar?: string
-  applyLoopVar?: string
+  audioBuffer: AudioBuffer | null
+  ctx: AudioContext | null
+  applyLoop: Function
 }
-const { audioBufferVar = 'currentAudioBuffer', ctxVar = 'audioContext', applyLoopVar = 'applyLoop' } = Astro.props
+const { audioBuffer, ctx, applyLoop } = Astro.props
 <button class="loop-btn" id="randomizeLoopBtn">🎲 Randomize Loop</button>
 
-<script>
+<script define:vars={{ audioBuffer, ctx, applyLoop }}>
   import { randomSequence } from '../core/loopPlayground.js'
   document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('randomizeLoopBtn')
     const statusEl = document.getElementById('statusDisplay')
     btn?.addEventListener('click', async () => {
-      const buffer = window[audioBufferVar]
-      const ctx = window[ctxVar]
-      const applyLoop = window[applyLoopVar]
-      if (!buffer || !ctx || typeof applyLoop !== 'function') return
-      const seq = randomSequence(buffer, { minMs: 10, maxMs: buffer.duration * 1000, steps: 4 })
-      if (statusEl) statusEl.textContent = seq.map(fn => fn.action).join(' -> ')
+      if (!audioBuffer || !ctx || typeof applyLoop !== 'function') return
+      const seq = randomSequence(audioBuffer, { minMs: 10, maxMs: audioBuffer.duration * 1000, steps: 4 })
+      if (statusEl) statusEl.textContent = seq.map(fn => fn.op || fn.action).join(' -> ')
+      let buf = audioBuffer
       for (const step of seq) {
         const { buffer: newBuf, loop } = step()
-        window[audioBufferVar] = newBuf
-        applyLoop(loop)
+        buf = newBuf
+        applyLoop(buf, loop, step.op || step.action)
         await new Promise(r => setTimeout(r, 500))
       }
       if (statusEl) statusEl.textContent = 'Randomization done'


### PR DESCRIPTION
## Summary
- use props in `RandomizerButton` instead of global variables
- pass current audio state to `RandomizerButton` from `AudioAnalyzer`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466229e8d88325812d2142946bb647