### PR TITLE
Add beat glitch utilities

### DIFF
--- a/src/components/GlitchPlayground.astro
+++ b/src/components/GlitchPlayground.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  audioBufferVar?: string
+  applyLoopVar?: string
+}
+const { audioBufferVar = 'currentAudioBuffer', applyLoopVar = 'applyLoop' } = Astro.props
+---
+<button id="glitchToggleBtn">Start Glitch</button>
+
+<script>
+  import { startBeatGlitch } from '../core/beatGlitcher.js'
+  let stop = null
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('glitchToggleBtn')
+    btn?.addEventListener('click', () => {
+      if (!stop) {
+        const buffer = window[audioBufferVar]
+        const applyLoop = window[applyLoopVar]
+        if (!buffer || typeof applyLoop !== 'function') return
+        stop = startBeatGlitch(buffer, {
+          maxOpsPerBar: 1,
+          onUpdate: res => applyLoop(res.buffer, res.loop, res.op)
+        })
+        btn.textContent = 'Stop Glitch'
+      } else {
+        stop()
+        stop = null
+        btn.textContent = 'Start Glitch'
+      }
+    })
+  })
+</script>
+
+<style>
+#glitchToggleBtn { margin-top: .5rem; padding: .4rem .8rem; }
+</style>

--- a/src/core/GibClock.js
+++ b/src/core/GibClock.js
@@ -1,0 +1,32 @@
+export class GibClock {
+  constructor(intervalMs) {
+    this.intervalMs = intervalMs;
+    this.timer = null;
+    this.callback = null;
+    this.nextTime = 0;
+  }
+
+  start(callback) {
+    if (this.timer) return;
+    this.callback = callback;
+    this.nextTime = Date.now() + this.intervalMs;
+    this.timer = setTimeout(() => this._tick(), this.intervalMs);
+  }
+
+  _tick() {
+    if (typeof this.callback === 'function') {
+      this.callback();
+    }
+    const now = Date.now();
+    this.nextTime += this.intervalMs;
+    const delay = Math.max(0, this.nextTime - now);
+    this.timer = setTimeout(() => this._tick(), delay);
+  }
+
+  stop() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/core/beatGlitcher.js
+++ b/src/core/beatGlitcher.js
@@ -1,0 +1,20 @@
+import { fastBPMDetect } from '../scripts/analysis/BPMDetector.ts';
+import { randomSequence } from './loopPlayground.js';
+import { GibClock } from './GibClock.js';
+
+export function startBeatGlitch(audioBuffer, { maxOpsPerBar = 1, onUpdate } = {}) {
+  if (!audioBuffer) throw new Error('audioBuffer required');
+  const bpm = fastBPMDetect(audioBuffer);
+  const barMs = (60 / bpm) * 4 * 1000;
+  const clock = new GibClock(barMs);
+
+  clock.start(() => {
+    const seq = randomSequence(audioBuffer, { steps: maxOpsPerBar });
+    for (const step of seq) {
+      const res = step();
+      if (typeof onUpdate === 'function') onUpdate(res);
+    }
+  });
+
+  return () => clock.stop();
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -7,3 +7,5 @@ export {
   reverseBufferSection,
 } from './loopHelpers.js';
 export { randomSequence } from './loopPlayground.js';
+export { startBeatGlitch } from './beatGlitcher.js';
+export { GibClock } from './GibClock.js';

--- a/src/index.js
+++ b/src/index.js
@@ -20,3 +20,5 @@ export { SpectrumAnalyzer } from './scripts/SpectrumAnalyzer.js'
 // Utility functions
 // Export the main PlecoXA class, which provides core audio analysis and processing features, making it the primary export for npm consumers
 export { PlecoXA } from './scripts/pleco-xa.js'
+
+export { startBeatGlitch, GibClock } from './core/index.js'

--- a/tests/beatGlitcher.test.js
+++ b/tests/beatGlitcher.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { startBeatGlitch } from '../src/core/beatGlitcher.js'
+
+vi.mock('../src/scripts/analysis/BPMDetector.ts', () => ({
+  fastBPMDetect: () => 120
+}))
+
+vi.mock('../src/core/loopPlayground.js', () => ({
+  randomSequence: (buffer, { steps }) => {
+    const fn = () => ({ buffer, loop: { start: 0, end: 1 }, op: 'noop' })
+    return new Array(steps).fill(fn)
+  }
+}))
+
+describe('startBeatGlitch', () => {
+  it('triggers onUpdate once per bar', () => {
+    vi.useFakeTimers()
+    const audioBuffer = {
+      getChannelData: () => new Float32Array(1),
+      numberOfChannels: 1,
+      sampleRate: 44100,
+      length: 44100
+    }
+    const onUpdate = vi.fn()
+    const stop = startBeatGlitch(audioBuffer, { maxOpsPerBar: 1, onUpdate })
+    vi.advanceTimersByTime(4000 + 50)
+    stop()
+    expect(onUpdate).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add GibClock scheduler utility
- implement startBeatGlitch using BPM-based timing
- expose new utilities from index files
- create GlitchPlayground component for starting/stopping the glitch engine
- test beatGlitcher with fake timers

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846625421888325b0478937e65eaffe