### PR TITLE
Add setup instructions and script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Pleco Xa
+
+Thank you for considering a contribution!
+
+## Development setup
+
+Install all project dependencies before running tests or the development server:
+
+```bash
+npm install
+```
+
+This command installs both production and development packages, including the `vitest` test runner.
+
+Alternatively, run the helper script:
+
+```bash
+npm run setup
+```
+
+## Running tests
+
+After installing dependencies, execute:
+
+```bash
+npm test
+```
+
+We use [Vitest](https://vitest.dev/) for the test suite.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,17 @@ path to verify the server is up and running.
 
 Contributions are welcome! Feel free to open issues or pull requests on GitHub.
 
+Before running the test suite or the development server, install the project's
+dependencies:
+
+```bash
+npm install
+```
+
+This fetches dev tools such as `vitest`. You can also run `npm run setup` which
+wraps the above command. See [CONTRIBUTING.md](CONTRIBUTING.md) for more
+details.
+
 ## License
 
 MIT License - See LICENSE file for details.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "astro preview --port $PORT --host",
-    "test": "vitest"
+    "test": "vitest",
+    "setup": "npm install"
   },
   "dependencies": {
     "@astrojs/node": "^9.2.2",


### PR DESCRIPTION
## Summary
- mention `npm install` in the Contributing section of README
- add a new CONTRIBUTING guide with development setup info
- add `setup` script in `package.json` for convenience

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684663f1fde88325bdf4e8a3b80598de