### PR TITLE
Disable reverse loop on full track

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -982,18 +982,22 @@ const {
   // Update loop info in UI
   function updateLoopInfo(loopData) {
     if (!currentAudioBuffer || !loopData) return;
-    
+
     const startTime = loopData.start * currentAudioBuffer.duration;
     const endTime = loopData.end * currentAudioBuffer.duration;
     const duration = endTime - startTime;
-    
+
+    const reverseBtn = document.getElementById('reverseLoopBtn');
+
     let loopText;
     if (loopData.start === 0 && loopData.end === 1) {
       loopText = 'Full Track';
+      if (reverseBtn) reverseBtn.disabled = true;
     } else {
       loopText = `${duration.toFixed(2)}s (${startTime.toFixed(2)}s - ${endTime.toFixed(2)}s)`;
+      if (reverseBtn) reverseBtn.disabled = false;
     }
-    
+
     document.getElementById('loopInfo').textContent = loopText;
   }
 

--- a/src/scripts/audio-analysis.js
+++ b/src/scripts/audio-analysis.js
@@ -1053,10 +1053,14 @@ function updateLoopInfo() {
   const endTime = currentLoop.end * currentAudioBuffer.duration
   const duration = endTime - startTime
 
+  const reverseBtn = document.getElementById('reverseLoopBtn')
+
   let loopText
   if (currentLoop.start === 0 && currentLoop.end === 1) {
     loopText = 'Full Track'
+    if (reverseBtn) reverseBtn.disabled = true
   } else {
+    if (reverseBtn) reverseBtn.disabled = false
     // Calculate musical division if we have BPM
     if (currentBPM > 0) {
       const beatDuration = 60 / currentBPM


### PR DESCRIPTION
## Summary
- disable the Reverse Loop button when the full track is selected
- mirror that logic in the standalone audio-analysis script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846641123dc83259c134193080ad4cb