### PR TITLE
Implement toast message queue

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -101,8 +101,6 @@ const {
     </div>
   </div>
 
-  <div id="errorDisplay"></div>
-  <div id="statusDisplay"></div>
 
   <slot />
 </div>
@@ -344,32 +342,6 @@ const {
     line-height: 1.4;
   }
 
-  #errorDisplay {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    background: #ff4444;
-    color: white;
-    padding: 15px 20px;
-    border-radius: 8px;
-    z-index: 1000;
-    max-width: 400px;
-    display: none;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
-  }
-
-  #statusDisplay {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: #444;
-    color: white;
-    padding: 10px 15px;
-    border-radius: 8px;
-    z-index: 1000;
-    display: none;
-    max-width: 400px;
-  }
 
   @media (max-width: 768px) {
     .analysis-display {
@@ -398,6 +370,7 @@ const {
   import { detectBPM, detectBPMWindow } from '../scripts/analysis/BPMDetector.ts';
 
   import { findLoop, manipulateLoop } from '../scripts/xa-loop-detection.js';
+  import { enqueueToast } from '../scripts/ui/toastQueue.js';
 
   // Worker for heavy analysis
   let analysisWorker = null;
@@ -1014,23 +987,11 @@ const {
   
   // Show error message
   function showError(message) {
-    const errorDiv = document.getElementById('errorDisplay');
-    errorDiv.textContent = message;
-    errorDiv.style.display = 'block';
-
-    setTimeout(() => {
-      errorDiv.style.display = 'none';
-    }, 5000);
+    enqueueToast(message, 5000);
   }
 
   function showStatus(message) {
-    const statusDiv = document.getElementById('statusDisplay');
-    if (!statusDiv) return;
-    statusDiv.textContent = message;
-    statusDiv.style.display = 'block';
-    setTimeout(() => {
-      statusDiv.style.display = 'none';
-    }, 2000);
+    enqueueToast(message, 2000);
   }
 
   function applyLoop(loopData) {

--- a/src/components/RandomizerButton.astro
+++ b/src/components/RandomizerButton.astro
@@ -8,13 +8,13 @@ const { audioBuffer, ctx, applyLoop } = Astro.props
 
 <script define:vars={{ audioBuffer, ctx, applyLoop }}>
   import { randomSequence } from '../core/loopPlayground.js'
+  import { enqueueToast } from '../scripts/ui/toastQueue.js'
   document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('randomizeLoopBtn')
-    const statusEl = document.getElementById('statusDisplay')
     btn?.addEventListener('click', async () => {
       if (!audioBuffer || !ctx || typeof applyLoop !== 'function') return
       const seq = randomSequence(audioBuffer, { minMs: 10, maxMs: audioBuffer.duration * 1000, steps: 4 })
-      if (statusEl) statusEl.textContent = seq.map(fn => fn.op || fn.action).join(' -> ')
+      enqueueToast(seq.map(fn => fn.op || fn.action).join(' -> '))
       let buf = audioBuffer
       for (const step of seq) {
         const { buffer: newBuf, loop } = step()
@@ -22,7 +22,7 @@ const { audioBuffer, ctx, applyLoop } = Astro.props
         applyLoop(buf, loop, step.op || step.action)
         await new Promise(r => setTimeout(r, 500))
       }
-      if (statusEl) statusEl.textContent = 'Randomization done'
+      enqueueToast('Randomization done')
 
     })
   })

--- a/src/scripts/audio-analysis.js
+++ b/src/scripts/audio-analysis.js
@@ -8,6 +8,7 @@ import { fastBPMDetect } from './xa-beat.js'
 
 // Advanced beat tracking with phase detection
 import { BeatTracker } from './xa-beat-tracker.js'
+import { enqueueToast } from './ui/toastQueue.js'
 
 // Onset detection for transients
 
@@ -62,13 +63,7 @@ window.addEventListener('unhandledrejection', (e) => {
 })
 
 function showError(message) {
-  const errorDiv = document.getElementById('errorDisplay')
-  errorDiv.textContent = message
-  errorDiv.style.display = 'block'
-
-  setTimeout(() => {
-    errorDiv.style.display = 'none'
-  }, 5000)
+  enqueueToast(message, 5000)
 }
 
 // ===== INITIALIZATION =====

--- a/src/scripts/pleco-xa.js
+++ b/src/scripts/pleco-xa.js
@@ -5,6 +5,7 @@
 
 import { AudioPlayer } from './analysis/AudioPlayer.ts'
 import { LoopController } from './loop-controller.js'
+import { enqueueToast } from './ui/toastQueue.js'
 
 export class PlecoXA {
   constructor(options = {}) {
@@ -263,26 +264,7 @@ export class PlecoXA {
       return
     }
 
-    let errorDisplay = document.getElementById('errorDisplay')
-    if (!errorDisplay) {
-      errorDisplay = document.createElement('div')
-      errorDisplay.id = 'errorDisplay'
-      errorDisplay.style.color = 'red'
-      errorDisplay.style.padding = '10px'
-      errorDisplay.style.margin = '10px 0'
-      errorDisplay.style.border = '1px solid red'
-      errorDisplay.style.borderRadius = '4px'
-      errorDisplay.style.display = 'none'
-      document.body.appendChild(errorDisplay)
-    }
-
-    errorDisplay.textContent = message
-    errorDisplay.style.display = 'block'
-
-    // Auto-hide after 5 seconds
-    setTimeout(() => {
-      errorDisplay.style.display = 'none'
-    }, 5000)
+    enqueueToast(message, 5000)
   }
 
   /**

--- a/src/scripts/ui/toastQueue.js
+++ b/src/scripts/ui/toastQueue.js
@@ -1,0 +1,41 @@
+let queue = []
+let container = null
+
+function ensureContainer() {
+  if (typeof document === 'undefined') return
+  if (!container) {
+    container = document.getElementById('toastContainer')
+    if (!container) {
+      container = document.createElement('div')
+      container.id = 'toastContainer'
+      container.setAttribute('aria-live', 'polite')
+      container.style.position = 'fixed'
+      container.style.top = '20px'
+      container.style.right = '20px'
+      container.style.display = 'flex'
+      container.style.flexDirection = 'column'
+      container.style.gap = '10px'
+      container.style.zIndex = '1000'
+      document.body.appendChild(container)
+    }
+  }
+}
+
+function showNext() {
+  if (!container || container.childElementCount || queue.length === 0) return
+  const { message, duration } = queue.shift()
+  const div = document.createElement('div')
+  div.className = 'toast-message'
+  div.textContent = message
+  container.appendChild(div)
+  setTimeout(() => {
+    div.remove()
+    showNext()
+  }, duration)
+}
+
+export function enqueueToast(message, duration = 3000) {
+  ensureContainer()
+  queue.push({ message, duration })
+  showNext()
+}

--- a/src/styles/import.scss
+++ b/src/styles/import.scss
@@ -3,3 +3,22 @@
 @use 'sass:map';
 
 // Placeholder for additional style imports
+
+#toastContainer {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 1000;
+}
+
+.toast-message {
+  background: #444;
+  color: #fff;
+  padding: 10px 15px;
+  border-radius: 4px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  max-width: 400px;
+}


### PR DESCRIPTION
## Summary
- create a small toast queue module
- use the toast queue for error and status messages
- update RandomizerButton to use toast queue
- add basic toast styles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846640f973c8325a03debb9a4dafedc