### PR TITLE
Fix AudioContext imports

### DIFF
--- a/tests/librosa-loop-analysis.test.js
+++ b/tests/librosa-loop-analysis.test.js
@@ -1,5 +1,5 @@
 import { librosaLoopAnalysis } from '../src/scripts/loop-analyzer.js'
-import { AudioContext } from 'web-audio-test-api'
+import { AudioContext } from '../web-audio-test-api/index.js'
 
 // Minimal stub for OfflineAudioContext used in spectrum analysis
 class MockOfflineAudioContext {

--- a/tests/loop-analysis.test.js
+++ b/tests/loop-analysis.test.js
@@ -2,7 +2,7 @@ import {
   musicalLoopAnalysis,
   analyzeLoopPoints,
 } from '../src/scripts/loop-analyzer.js'
-import { AudioContext } from 'web-audio-test-api'
+import { AudioContext } from '../web-audio-test-api/index.js'
 
 function createLoopBuffer(loopLengthSeconds, repeats, sampleRate = 44100) {
   const ctx = new AudioContext({ sampleRate })

--- a/tests/randomSequence.test.js
+++ b/tests/randomSequence.test.js
@@ -1,5 +1,5 @@
 const { randomSequence } = require('../src/core/loopPlayground.js');
-const { AudioContext } = require('web-audio-test-api');
+const { AudioContext } = require('../web-audio-test-api');
 
 test('randomSequence returns correct length and function outputs', () => {
   const ctx = new AudioContext();

--- a/tests/signature-demo.test.js
+++ b/tests/signature-demo.test.js
@@ -1,5 +1,5 @@
 import { signatureDemo } from '../src/core/index.js';
-import { AudioContext } from 'web-audio-test-api';
+import { AudioContext } from '../web-audio-test-api/index.js';
 
 describe('signatureDemo', () => {
   it('returns expected number of steps', () => {

--- a/web-audio-test-api/package.json
+++ b/web-audio-test-api/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "type": "module",
+  "type": "commonjs",
   "description": "Mock Web Audio API implementation for testing",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- rename the web-audio-test-api config to package.json and mark it as commonjs
- update tests to import the mock AudioContext using a relative path

## Testing
- `npx vitest --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684663f7e8a8832589d32d2079fec024