### PR TITLE
Fix analysisWorker import paths

### DIFF
--- a/src/workers/analysisWorker.js
+++ b/src/workers/analysisWorker.js
@@ -1,5 +1,5 @@
-import { detectBPM } from '../scripts/analysis/BPMDetector.ts';
-import { analyzeLoop } from '../scripts/analysis/LoopAnalyzer.ts';
+import { detectBPM } from '../scripts/analysis/BPMDetector.js';
+import { analyzeLoop } from '../scripts/analysis/LoopAnalyzer.js';
 import { fastBPMDetect } from '../scripts/analysis/BPMDetector.js';
 import { fastLoopAnalysis } from '../scripts/xa-loop.js';
 


### PR DESCRIPTION
## Summary
- update worker to load compiled JS modules instead of TypeScript sources

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684666144c608325959bd3d7b3eac0dd