### PR TITLE
chore: modernize web-audio-test-api stub

### DIFF
--- a/web-audio-test-api/index.js
+++ b/web-audio-test-api/index.js
@@ -25,10 +25,12 @@ class AudioContext {
   }
 }
 
-module.exports = { AudioContext, AudioBuffer }
+export { AudioContext, AudioBuffer }
 
-const ctx = new (window.AudioContext ||
-  window.webkitAudioContext ||
-  function () {
-    throw new Error('AudioContext not supported')
-  })()
+if (typeof window !== 'undefined') {
+  const ctx = new (window.AudioContext ||
+    window.webkitAudioContext ||
+    function () {
+      throw new Error('AudioContext not supported')
+    })()
+}


### PR DESCRIPTION
## Summary
- modernize the Web Audio stub to use ES module exports
- guard the `window.AudioContext` detection so tests don't break in Node

## Testing
- `npm test` *(fails: 8 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846695efb548325a02f94354a309320