### PR TITLE
Fix Vitest imports

### DIFF
--- a/tests/audio-utils.test.js
+++ b/tests/audio-utils.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import {
   computeRMS,
   computePeak,

--- a/tests/bpm-detector.test.js
+++ b/tests/bpm-detector.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { detectBPM } from '../src/scripts/analysis/BPMDetector.ts'
 
 function createPulseSample(bpm, sampleRate, durationSeconds) {

--- a/tests/compression.test.js
+++ b/tests/compression.test.js
@@ -1,4 +1,6 @@
+import { describe, it, expect } from 'vitest'
+
 // compression.test.js – placeholder
 describe('compression utilities (placeholder)', () => {
-  test('work-in-progress', () => expect(true).toBe(true))
+  it('work-in-progress', () => expect(true).toBe(true))
 })

--- a/tests/librosa-loop-analysis.test.js
+++ b/tests/librosa-loop-analysis.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { librosaLoopAnalysis } from '../src/scripts/loop-analyzer.js'
 import { AudioContext } from 'web-audio-test-api'
 

--- a/tests/loop-analysis.test.js
+++ b/tests/loop-analysis.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import {
   musicalLoopAnalysis,
   analyzeLoopPoints,

--- a/tests/musical-timing.test.js
+++ b/tests/musical-timing.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { calculateBeatAlignment } from '../src/scripts/musical-timing.js'
 
 describe('calculateBeatAlignment', () => {

--- a/tests/signature-demo.test.js
+++ b/tests/signature-demo.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { signatureDemo } from '../src/core/index.js';
 import { AudioContext } from 'web-audio-test-api';
 

--- a/tests/utils-audio-utils.test.js
+++ b/tests/utils-audio-utils.test.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import {
   findZeroCrossing,
   findAudioStart,


### PR DESCRIPTION
## Summary
- import `describe`, `it`, and `expect` from `vitest` in test files
- update compression test to use `it`

## Testing
- `npm test --silent` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684669abe7e88325b84023c7aaa6e764