### PR TITLE
Fix imports for BPMDetector and LoopAnalyzer

### DIFF
--- a/src/workers/analysisWorker.js
+++ b/src/workers/analysisWorker.js
@@ -1,6 +1,6 @@
-import { detectBPM } from '../scripts/analysis/BPMDetector.js';
-import { analyzeLoop } from '../scripts/analysis/LoopAnalyzer.js';
-import { fastBPMDetect } from '../scripts/analysis/BPMDetector.js';
+import { detectBPM } from '../scripts/analysis/BPMDetector.ts';
+import { analyzeLoop } from '../scripts/analysis/LoopAnalyzer.ts';
+import { fastBPMDetect } from '../scripts/analysis/BPMDetector.ts';
 import { fastLoopAnalysis } from '../scripts/xa-loop.js';
 
 self.onmessage = async (event) => {


### PR DESCRIPTION
## Summary
- point analysis worker imports to TypeScript sources

## Testing
- `npm test` *(fails: `Tests failed. Watching for file changes...`)*
- `npm run build` *(fails: Expected `}` but found `:`)*

------
https://chatgpt.com/codex/tasks/task_e_684669d063708325bf5e610c036deeef