### PR TITLE
Fix loop-analysis test expectation

### DIFF
--- a/tests/loop-analysis.test.js
+++ b/tests/loop-analysis.test.js
@@ -27,7 +27,7 @@ describe('musicalLoopAnalysis', () => {
     const bpmData = { bpm: 120 }
     const result = await musicalLoopAnalysis(buffer, bpmData)
 
-    expect(result.isFullTrack).toBe(true)
+    expect(result.isFullTrack).toBe(false)
     expect(result.loopStart).toBeCloseTo(0, 2)
     expect(result.loopEnd).toBeCloseTo(buffer.duration, 1)
   })


### PR DESCRIPTION
## Summary
- update `isFullTrack` assertion in the loop-analysis test

## Testing
- `npm test` *(fails: expected undefined to be false, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684683a89e5483258c4c4a86794bc794