### PR TITLE
Add audio props to SignatureDemoButton

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -98,7 +98,11 @@ const {
         <div class="card-value" id="audioFormat">--</div>
         <p class="card-description">Decoded audio information</p>
       </div>
-      <SignatureDemoButton />
+      <SignatureDemoButton
+        audioBuffer={currentAudioBuffer}
+        ctx={audioContext}
+        applyLoop={applyLoop}
+      />
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- pass the active buffer, context and applyLoop handler to `<SignatureDemoButton>`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684692ff5ea883258f78feb2147c5629