### PR TITLE
Remove console output from audio util tests

### DIFF
--- a/tests/utils-audio-utils.test.js
+++ b/tests/utils-audio-utils.test.js
@@ -40,7 +40,6 @@ describe('applyHannWindow', () => {
   it('applies a Hann window to the data', () => {
     const data = new Float32Array([1, 1, 1, 1])
     const result = applyHannWindow(data)
-    console.log('applyHannWindow output:', Array.from(result))
     // Hann window values for a 4-point window: 0, 0.5, 1, 0.5, 0
     // When applied to [1,1,1,1], we get [0, 0.5, 0.5, 0]
     expect(Array.from(result)).toEqual([0, 0.5, 0.5, 0])


### PR DESCRIPTION
## Summary
- clean up `applyHannWindow` test by removing a leftover `console.log`

## Testing
- `npm test` *(fails: 5 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68468e6dccf883259edf7c731ad23857