### PR TITLE
Implement reverseBufferSection utility

### DIFF
--- a/src/scripts/audio-utils.js
+++ b/src/scripts/audio-utils.js
@@ -184,6 +184,22 @@ export function computeZeroCrossingRate(audioBuffer) {
   return samples ? crossings / samples : 0
 }
 
+export function reverseBufferSection(buffer, start, end) {
+  for (let c = 0; c < buffer.numberOfChannels; c++) {
+    const data = buffer.getChannelData(c)
+    let i = 0
+    let j = end - start - 1
+    while (i < j) {
+      const a = data[start + i]
+      data[start + i] = data[start + j]
+      data[start + j] = a
+      i++
+      j--
+    }
+  }
+  return buffer
+}
+
 export function findZeroCrossing(data, startIndex) {
   for (let i = startIndex + 1; i < data.length; i++) {
     if ((data[i - 1] >= 0 && data[i] < 0) || (data[i - 1] < 0 && data[i] >= 0)) {

--- a/src/utils/audio-utils.d.ts
+++ b/src/utils/audio-utils.d.ts
@@ -7,3 +7,4 @@ export declare function computeZeroCrossingRate(audioBuffer: AudioBuffer): numbe
 export declare function findAllZeroCrossings(audioData: Float32Array, start: number): number[];
 export declare function findAudioStart(audioData: Float32Array, sampleRate: number): number;
 export declare function applyHannWindow(audioData: Float32Array): Float32Array;
+export declare function reverseBufferSection(buffer: AudioBuffer, start: number, end: number): AudioBuffer;

--- a/tests/audio-utils.test.js
+++ b/tests/audio-utils.test.js
@@ -3,6 +3,7 @@ import {
   computeRMS,
   computePeak,
   computeZeroCrossingRate,
+  reverseBufferSection,
 } from '../src/scripts/audio-utils.js'
 
 function createAudioBuffer(samples) {
@@ -47,6 +48,14 @@ describe('audio utils', () => {
       const buffer = createAudioBuffer([1, 1, 1, 1])
       const zcr = computeZeroCrossingRate(buffer)
       expect(zcr).toBe(0)
+    })
+  })
+
+  describe('reverseBufferSection', () => {
+    it('reverses a section of the buffer in place', () => {
+      const buffer = createAudioBuffer([1, 2, 3, 4, 5])
+      reverseBufferSection(buffer, 1, 4)
+      expect(Array.from(buffer.getChannelData())).toEqual([1, 4, 3, 2, 5])
     })
   })
 })


### PR DESCRIPTION
## Summary
- expose `reverseBufferSection` in audio utils
- update type declarations
- test reversing a buffer segment

## Testing
- `npm test --silent` *(fails: Error: Cannot find package 'jsdom' imported from tests/signature-button.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6846966e7a108325962fa27c2d5d921c