### PR TITLE
Export DSP helpers

### DIFF
--- a/src/components/GlitchPlayground.astro
+++ b/src/components/GlitchPlayground.astro
@@ -8,7 +8,7 @@ const { audioBufferVar = 'currentAudioBuffer', applyLoopVar = 'applyLoop' } = As
 <button id="glitchToggleBtn">Start Glitch</button>
 
 <script>
-  import { startBeatGlitch } from '../core/beatGlitcher.js'
+  import { startBeatGlitch } from '../core/index.js'
   let stop = null
   document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('glitchToggleBtn')

--- a/src/components/RandomizerButton.astro
+++ b/src/components/RandomizerButton.astro
@@ -19,7 +19,7 @@ const { audioBufferVar = 'currentAudioBuffer', ctxVar = 'audioContext', applyLoo
 </button>
 
 <script>
-  import { randomSequence } from '../core/loopPlayground.js';
+  import { randomSequence } from '../core/index.js';
   import { enqueueToast } from '../scripts/ui/toastQueue.js';
   document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('randomizeLoopBtn');

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -9,3 +9,26 @@ export {
 export { randomSequence, glitchBurst } from './loopPlayground.js';
 export { startBeatGlitch } from './beatGlitcher.js';
 export { GibClock } from './GibClock.js';
+
+// DSP helper utilities
+export {
+  createLoopBuffer,
+  exportBufferAsWav,
+  computeRMS,
+  defineMultipleLoopPoints,
+  computePeak,
+  computeZeroCrossingRate,
+  findZeroCrossing,
+  findAllZeroCrossings,
+  findAudioStart,
+  applyHannWindow,
+} from '../scripts/audio-utils.js';
+
+// Audio compression helpers
+export { pitchBasedCompress, tempoBasedCompress } from '../scripts/compression.js';
+
+// Musical timing utilities
+export { calculateBeatAlignment } from '../scripts/musical-timing.js';
+
+// Debug utilities
+export { debugLog, setDebug, isDebugEnabled } from '../scripts/debug.js';


### PR DESCRIPTION
## Summary
- re-export helper functions and utilities in `src/core`
- import from the new index in components

## Testing
- `npm test` *(fails: vitest not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_684696712d148325b1c40c4afe67c259