### PR TITLE
Introduce clock-based glitchBurst

### DIFF
--- a/src/core/GibClock.js
+++ b/src/core/GibClock.js
@@ -2,21 +2,27 @@ export class GibClock {
   constructor(intervalMs) {
     this.intervalMs = intervalMs;
     this.timer = null;
-    this.callback = null;
+    this.listeners = new Set();
     this.nextTime = 0;
   }
 
+  onTick(callback) {
+    if (typeof callback === 'function') this.listeners.add(callback);
+  }
+
+  offTick(callback) {
+    this.listeners.delete(callback);
+  }
+
   start(callback) {
+    if (callback) this.onTick(callback);
     if (this.timer) return;
-    this.callback = callback;
     this.nextTime = Date.now() + this.intervalMs;
     this.timer = setTimeout(() => this._tick(), this.intervalMs);
   }
 
   _tick() {
-    if (typeof this.callback === 'function') {
-      this.callback();
-    }
+    for (const cb of this.listeners) cb();
     const now = Date.now();
     this.nextTime += this.intervalMs;
     const delay = Math.max(0, this.nextTime - now);

--- a/src/core/loopPlayground.js
+++ b/src/core/loopPlayground.js
@@ -5,6 +5,7 @@ import {
   moveForward,
   reverseBufferSection,
 } from './loopHelpers.js';
+import { GibClock } from './GibClock.js';
 
 export function randomSequence(
   buffer,
@@ -135,15 +136,23 @@ export function glitchBurst(buffer, {
     return subOps;
   };
 
+  const clock = new GibClock(100);
+
   const step = () => {
-    if (performance.now() - start >= durationMs) return;
+    if (performance.now() - start >= durationMs) {
+      clock.stop();
+      return;
+    }
 
     const op = pickOp();
     const subOps = applyOp(op);
     onUpdate(buffer, loop, op, subOps);
 
-    setTimeout(step, 100 + Math.random() * 100);
+    clock.intervalMs = 100 + Math.random() * 100;
   };
 
-  step();
+  clock.onTick(step);
+  clock.start();
+
+  return () => clock.stop();
 }


### PR DESCRIPTION
## Summary
- add `onTick` helper to `GibClock`
- refactor `glitchBurst` to use `GibClock` instead of `setTimeout`

## Testing
- `npm test` *(fails: Cannot find package 'jsdom', Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68469673cb988325b229312efb342ce6