### PR TITLE
Add tests for buffer reversal, deterministic glitch burst, and signature operations

### DIFF
--- a/tests/reverseBufferSection.test.js
+++ b/tests/reverseBufferSection.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { AudioContext } from '../web-audio-test-api/index.js'
+import { reverseBufferSection } from '../src/core/index.js'
+
+describe('reverseBufferSection', () => {
+  it('reverses the given range on all channels', () => {
+    const ctx = new AudioContext({ sampleRate: 44100 })
+    const buffer = ctx.createBuffer(2, 4, 44100)
+    buffer.getChannelData(0).set([1, 2, 3, 4])
+    buffer.getChannelData(1).set([5, 6, 7, 8])
+
+    reverseBufferSection(buffer, 0, buffer.length)
+
+    expect(Array.from(buffer.getChannelData(0))).toEqual([4, 3, 2, 1])
+    expect(Array.from(buffer.getChannelData(1))).toEqual([8, 7, 6, 5])
+  })
+})

--- a/tests/signature-demo.test.js
+++ b/tests/signature-demo.test.js
@@ -1,12 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { signatureDemo } from '../src/core/index.js';
-import { AudioContext } from 'web-audio-test-api';
+import { signatureDemo } from '../src/core/index.js'
+import { AudioContext } from '../web-audio-test-api/index.js'
 
 describe('signatureDemo', () => {
-  it('returns expected number of steps', () => {
-    const ctx = new AudioContext({ sampleRate: 44100 });
-    const buffer = ctx.createBuffer(1, 44100, 44100);
-    const steps = signatureDemo(buffer);
-    expect(steps).toHaveLength(60);
-  });
-});
+  it('produces steps with expected operations', () => {
+    const ctx = new AudioContext({ sampleRate: 44100 })
+    const buffer = ctx.createBuffer(1, 44100, 44100)
+    const steps = signatureDemo(buffer)
+    const ops = steps.map(s => s.op)
+
+    expect(ops.slice(0, 5)).toEqual(['half', 'half', 'half', 'half', 'reverse'])
+    expect(ops).toContain('move×3')
+    expect(ops.slice(-5)).toEqual(['move×2', 'double', 'reverse', 'move×1', 'reverse'])
+    expect(steps).toHaveLength(60)
+  })
+})


### PR DESCRIPTION
## Summary
- test reverseBufferSection across channels
- verify glitchBurst with mocked RNG
- check operation order in signatureDemo example

## Testing
- `npx vitest run tests/glitchBurst.test.js tests/reverseBufferSection.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68469676e1588325ad8ec8367a080408