### PR TITLE
Update docs: use npm ci for dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,12 @@ Thank you for considering a contribution!
 Install all project dependencies before running tests or the development server:
 
 ```bash
-npm install
+npm ci
 ```
 
-This command installs both production and development packages, including the `vitest` test runner.
+This command installs both production and development packages exactly as locked
+in `package-lock.json`, including the `vitest` test runner. It ensures
+reproducible installs across environments.
 
 Alternatively, run the helper script:
 

--- a/README.md
+++ b/README.md
@@ -395,12 +395,12 @@ Before running the test suite or the development server, install the project's
 dependencies:
 
 ```bash
-npm install
+npm ci
 ```
 
-This fetches dev tools such as `vitest`. You can also run `npm run setup` which
-wraps the above command. See [CONTRIBUTING.md](CONTRIBUTING.md) for more
-details.
+This fetches dev tools such as `vitest` using the lockfile for reproducible
+installs. You can also run `npm run setup` which wraps the above command.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "start": "astro preview --port $PORT --host",
     "test": "vitest",
-    "setup": "npm install"
+    "setup": "npm ci"
   },
   "dependencies": {
     "@astrojs/node": "^9.2.2",


### PR DESCRIPTION
## Summary
- use `npm ci` to install dev dependencies in contributing docs
- show `npm ci` in README contributing section
- change `npm run setup` script to run `npm ci`

## Testing
- `npm ci`
- `npm test` *(fails: performance.now is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684696786a0083259ed8273717cf8217