### PR TITLE
Fix AudioAnalyzer SSR error

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -362,7 +362,7 @@ const {
   }
 </style>
 
-<script>
+<script client:load>
   // Import core functionality
   import {
     initAudioProcessor,
@@ -387,8 +387,10 @@ const {
   let audioContext;
   let audioProcessor;
   let currentAudioBuffer = null;
-  window.currentAudioBuffer = null;
-  window.audioContext = null;
+  if (typeof window !== 'undefined') {
+    window.currentAudioBuffer ||= null;
+    window.audioContext ||= null;
+  }
   let isPlaying = false;
   let currentBeats = []; // Store beat times from BPM detection
   let currentTrackName = '';


### PR DESCRIPTION
## Summary
- guard browser-only globals in `AudioAnalyzer.astro`

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_684696fb6ea88325b44e87b5896c6eb5