### PR TITLE
Add Stripe backend example directory

### DIFF
--- a/deploying/README.md
+++ b/deploying/README.md
@@ -1,0 +1,24 @@
+# Stripe Checkout Backend
+
+This folder contains a minimal Stripe Checkout API used for premium features.
+It exposes two endpoints:
+
+- `POST /create-session` handled by `createSession.js`
+- `GET /success` handled by `success.js`
+
+The `server.js` file wires these handlers into a small Express app. Configure
+the following environment variables before deployment:
+
+- `STRIPE_SECRET_KEY` – your Stripe secret key
+- `STRIPE_PRICE_ID` – price identifier for the product
+- `BASE_URL` – base URL of your deployed site
+
+To run locally:
+
+```bash
+npm ci
+node deploying/railway-api/server.js
+```
+
+Railway or other serverless providers can use the included `.nixpacks.toml` to
+install Node 20 and execute the server with `npm start`.

--- a/deploying/railway-api/.nixpacks.toml
+++ b/deploying/railway-api/.nixpacks.toml
@@ -1,0 +1,8 @@
+[phases.setup]
+nixPkgs = ["nodejs_20"]
+
+[phases.install]
+cmds = ["npm ci"]
+
+[start]
+cmd = "node server.js"

--- a/deploying/railway-api/createSession.js
+++ b/deploying/railway-api/createSession.js
@@ -1,0 +1,25 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+export default async function createSession(req, res) {
+  try {
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      mode: 'payment',
+      line_items: [
+        {
+          price: process.env.STRIPE_PRICE_ID,
+          quantity: 1
+        }
+      ],
+      success_url: `${process.env.BASE_URL}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.BASE_URL}/cancel`
+    });
+
+    res.json({ id: session.id });
+  } catch (err) {
+    console.error('Error creating Stripe session:', err);
+    res.status(500).json({ error: 'Unable to create session' });
+  }
+}

--- a/deploying/railway-api/server.js
+++ b/deploying/railway-api/server.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import createSession from './createSession.js';
+import success from './success.js';
+
+const app = express();
+app.use(express.json());
+
+app.post('/create-session', createSession);
+app.get('/success', success);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/deploying/railway-api/success.js
+++ b/deploying/railway-api/success.js
@@ -1,0 +1,18 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+export default async function success(req, res) {
+  try {
+    const sessionId = req.query.session_id;
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    if (session.payment_status === 'paid') {
+      res.send('Payment verified');
+    } else {
+      res.status(400).send('Payment not complete');
+    }
+  } catch (err) {
+    console.error('Error verifying Stripe session:', err);
+    res.status(500).send('Unable to verify session');
+  }
+}


### PR DESCRIPTION
## Summary
- add `deploying/railway-api` folder with example Express server
- provide handlers `createSession.js` and `success.js`
- include Nixpacks config for Railway deployments
- add deployment README with setup instructions

## Testing
- `npm ci`
- `npm test` *(fails: expected values mismatch, aborts after running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2c2d8a48325a1a779f554ac3cf6