### PR TITLE
Handle write errors in upload endpoint

### DIFF
--- a/src/scripts/api/upload-audio.js
+++ b/src/scripts/api/upload-audio.js
@@ -54,7 +54,20 @@ export async function POST({ request }) {
     const arrayBuffer = await audioFile.arrayBuffer()
     const buffer = Buffer.from(arrayBuffer)
 
-    fs.writeFileSync(filePath, buffer)
+    try {
+      fs.writeFileSync(filePath, buffer)
+    } catch (err) {
+      debugLog('Write failed:', err)
+      return new Response(
+        JSON.stringify({
+          error: 'Uploads are unsupported in the current environment',
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
 
     debugLog(`Audio file saved: ${filename}`)
 


### PR DESCRIPTION
## Summary
- wrap `fs.writeFileSync` in `src/scripts/api/upload-audio.js`
- log errors with `debugLog` and return 500 JSON response when writes fail

## Testing
- `npm test` *(fails: missing jsdom and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2c786f88325a5fda6f7155591fd