### PR TITLE
Fix Hann window test expectation

### DIFF
--- a/tests/utils-audio-utils.test.js
+++ b/tests/utils-audio-utils.test.js
@@ -40,8 +40,8 @@ describe('applyHannWindow', () => {
   it('applies a Hann window to the data', () => {
     const data = new Float32Array([1, 1, 1, 1])
     const result = applyHannWindow(data)
-    // Hann window values for a 4-point window: 0, 0.5, 1, 0.5, 0
-    // When applied to [1,1,1,1], we get [0, 0.5, 0.5, 0]
-    expect(Array.from(result)).toEqual([0, 0.5, 0.5, 0])
+    // Hann window values for a 4-point window: 0, 0.75, 0.75, 0
+    // When applied to [1, 1, 1, 1], we get [0, 0.75, 0.75, 0]
+    expect(Array.from(result)).toEqual([0, 0.75, 0.75, 0])
   })
 })


### PR DESCRIPTION
## Summary
- correct applyHannWindow expected values in utils-audio-utils test

## Testing
- `npm ci`
- `npm test` *(fails: can't find package 'jsdom' and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6846a6e37e908325b02510470ccff5f6