### PR TITLE
Fix zero crossing rate

### DIFF
--- a/src/scripts/audio-utils.js
+++ b/src/scripts/audio-utils.js
@@ -170,18 +170,27 @@ export function computePeak(audioBuffer) {
 
 export function computeZeroCrossingRate(audioBuffer) {
   const channels = audioBuffer.numberOfChannels || 1
-  let crossings = 0
-  let samples = 0
+  let totalRate = 0
+
   for (let ch = 0; ch < channels; ch++) {
     const data = audioBuffer.getChannelData(ch)
+    let crossings = 0
+
     for (let i = 1; i < data.length; i++) {
-      if ((data[i - 1] >= 0 && data[i] < 0) || (data[i - 1] < 0 && data[i] >= 0)) {
+      if (
+        (data[i - 1] >= 0 && data[i] < 0) ||
+        (data[i - 1] < 0 && data[i] >= 0)
+      ) {
         crossings++
       }
     }
-    samples += data.length - 1
+
+    if (data.length) {
+      totalRate += crossings / data.length
+    }
   }
-  return samples ? crossings / samples : 0
+
+  return channels ? totalRate / channels : 0
 }
 
 export function reverseBufferSection(buffer, start, end) {


### PR DESCRIPTION
## Summary
- compute zero crossing rate per-channel by dividing crossings by channel data length
- average zero crossing rate across channels

## Testing
- `npx vitest tests/audio-utils.test.js --run`

------
https://chatgpt.com/codex/tasks/task_e_6846a6dbd0b48325bcd1054ef54358ae