### PR TITLE
Switch GibClock timing to performance.now()

### DIFF
--- a/src/core/GibClock.js
+++ b/src/core/GibClock.js
@@ -17,13 +17,14 @@ export class GibClock {
   start(callback) {
     if (callback) this.onTick(callback);
     if (this.timer) return;
-    this.nextTime = Date.now() + this.intervalMs;
+    this.nextTime = performance.now() + this.intervalMs;
     this.timer = setTimeout(() => this._tick(), this.intervalMs);
   }
 
   _tick() {
     for (const cb of this.listeners) cb();
-    const now = Date.now();
+    if (!this.timer) return;
+    const now = performance.now();
     this.nextTime += this.intervalMs;
     const delay = Math.max(0, this.nextTime - now);
     this.timer = setTimeout(() => this._tick(), delay);


### PR DESCRIPTION
## Summary
- update `GibClock` to use `performance.now()`
- avoid scheduling another tick after `stop()`

## Testing
- `npx vitest run tests/glitchBurst.test.js` *(fails: expected 2 to be greater than or equal to 30)*

------
https://chatgpt.com/codex/tasks/task_e_6846a6e1b6a883259b08c6238f6453c1