### PR TITLE
Fix zero crossing index

### DIFF
--- a/src/scripts/audio-utils.js
+++ b/src/scripts/audio-utils.js
@@ -203,7 +203,7 @@ export function reverseBufferSection(buffer, start, end) {
 export function findZeroCrossing(data, startIndex) {
   for (let i = startIndex + 1; i < data.length; i++) {
     if ((data[i - 1] >= 0 && data[i] < 0) || (data[i - 1] < 0 && data[i] >= 0)) {
-      return i
+      return i - 1
     }
   }
   return startIndex


### PR DESCRIPTION
## Summary
- return index before sign change in `findZeroCrossing`

## Testing
- `npx vitest run tests/utils-audio-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6846a93fa4108325b96fced7bb481c44