### PR TITLE
Fix zero-crossing rate normalization

### DIFF
--- a/src/scripts/audio-utils.js
+++ b/src/scripts/audio-utils.js
@@ -179,7 +179,7 @@ export function computeZeroCrossingRate(audioBuffer) {
         crossings++
       }
     }
-    samples += data.length - 1
+    samples += data.length
   }
   return samples ? crossings / samples : 0
 }


### PR DESCRIPTION
## Summary
- adjust zero-crossing rate to normalize by sample count
- run unit tests for `audio-utils`

## Testing
- `npx vitest run tests/audio-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6846a93eed308325940580a383dca696