### PR TITLE
Fix AudioAnalyzer reference error

### DIFF
--- a/src/components/AudioAnalyzer.astro
+++ b/src/components/AudioAnalyzer.astro
@@ -12,11 +12,15 @@ import SignatureDemoButton from './SignatureDemoButton.astro';
 import RandomizerButton from './RandomizerButton.astro';
 import GlitchBurstButton from './GlitchBurstButton.astro';
 
-const { 
-  title = 'Audio Analysis', 
+const {
+  title = 'Audio Analysis',
   showControls = true,
-  class: className = '' 
+  class: className = ''
 } = Astro.props;
+
+let currentAudioBuffer = null;
+let audioContext = null;
+function applyLoop() {}
 ---
 
 <div class={`pleco-audio-analyzer ${className}`}>
@@ -384,9 +388,8 @@ const {
   let analysisWorker = null;
   
   // Initialize state
-  let audioContext;
   let audioProcessor;
-  let currentAudioBuffer = null;
+  currentAudioBuffer = null;
   if (typeof window !== 'undefined') {
     window.currentAudioBuffer ||= null;
     window.audioContext ||= null;


### PR DESCRIPTION
## Summary
- declare currentAudioBuffer, audioContext and applyLoop defaults in `AudioAnalyzer.astro`
- avoid redeclaring variables in client script

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a97f51b08325a83b9a9696322140