### PR TITLE
Fix signature demo test

### DIFF
--- a/tests/signature-button.test.js
+++ b/tests/signature-button.test.js
@@ -24,7 +24,7 @@ function setupDom() {
     const steps = signatureDemo(audioBuffer)
     for (const { fn, op } of steps) {
       const { buffer: newBuf, loop } = fn()
-      applyLoopFn(newBuf, loop, op)
+      applyLoop(newBuf, loop, op)
 
       await new Promise(r => setTimeout(r, 400))
     }


### PR DESCRIPTION
## Summary
- correct function call in `runDemo` so test spies trigger

## Testing
- `npx vitest run tests/signature-button.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6846ac6884a083259ed5d2e2f3094b40