### PR TITLE
Remove unused Dockerfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: node dist/server/entry.mjs

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "start": "astro preview --port $PORT --host",
+    "start": "node dist/server/entry.mjs",
     "test": "vitest",
     "setup": "npm ci"
   },


### PR DESCRIPTION
## Summary
- set the production entry command to `node dist/server/entry.mjs`
- update the Procfile to use the same entrypoint

## Testing
- `npm ci`
- `npm test` *(fails: ReferenceError: samples is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846b1bca8c88325a34ded85ae282ff4