### PR TITLE
Release 2.0.4 — npm page banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10914,7 +10914,7 @@
       }
     },
     "packages/pleco-xa": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",

--- a/packages/pleco-xa/CHANGELOG.md
+++ b/packages/pleco-xa/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `pleco-xa` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] — 2026-07-04
+
+Documentation release — no code changes.
+
+### Changed
+
+- The npm page now carries the project banner, and the README reflects the
+  latest measured test counts and claims.
+
 ## [2.0.3] — 2026-07-04
 
 Correctness and honesty release. No API-shape changes; degenerate inputs that
@@ -121,6 +130,7 @@ see below.
 Releases prior to `2.0.0` (the `1.x` line, published May–July 2025) predate this
 changelog; their history is available in the git tags.
 
+[2.0.4]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.4
 [2.0.3]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.3
 [2.0.2]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.2
 [2.0.1]: https://www.npmjs.com/package/pleco-xa/v/2.0.1

--- a/packages/pleco-xa/package.json
+++ b/packages/pleco-xa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pleco-xa",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "description": "Browser-native audio analysis engine: musical timing, BPM/beat tracking, spectral features, and intelligent loop detection",
   "license": "MIT",

--- a/packages/pleco-xa/src/scripts/xa-fileio.js
+++ b/packages/pleco-xa/src/scripts/xa-fileio.js
@@ -340,7 +340,7 @@ export async function find_files(directory, options = {}) {
  */
 export function cite(version = null) {
   // Metadata mirrors packages/pleco-xa/package.json (name, author, repository).
-  const libVersion = version || '2.0.3';
+  const libVersion = version || '2.0.4';
 
   const citation = `@software{pleco_xa,
   title        = {pleco-xa: Browser-native audio analysis engine},


### PR DESCRIPTION
Documentation release: ships the banner-bearing README (and current measured claims) to npmjs.com. No code changes. Gates: build:lib 0, check:types 0, 237/237 tests.