### PR TITLE
Release 2.0.5 — quality ledger in the package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10914,7 +10914,7 @@
       }
     },
     "packages/pleco-xa": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",

--- a/packages/pleco-xa/CHANGELOG.md
+++ b/packages/pleco-xa/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `pleco-xa` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] — 2026-07-05
+
+Documentation release — no code changes.
+
+### Added
+
+- **`VERIFICATION.md` ships in the package** — the quality ledger: a 51-row
+  declared-vs-achieved tolerance table, loop acceptance gates (±10 ms golden
+  lock on real audio), and documented edge-case contracts. The full reference
+  corpus and golden suites are public in the repository (`npm ci && npm test`
+  reproduces all 420 assertions).
+
+### Changed
+
+- Test counts updated to the public verification layer (47 suites / 420 tests).
+- Package size badge is now a static measured value (~89 kB min+gzip).
+
 ## [2.0.4] — 2026-07-04
 
 Documentation release — no code changes. This package now documents itself to
@@ -142,6 +159,7 @@ see below.
 Releases prior to `2.0.0` (the `1.x` line, published May–July 2025) predate this
 changelog; their history is available in the git tags.
 
+[2.0.5]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.5
 [2.0.4]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.4
 [2.0.3]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.3
 [2.0.2]: https://github.com/pleco-xa/pleco-xa/releases/tag/v2.0.2

--- a/packages/pleco-xa/package.json
+++ b/packages/pleco-xa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pleco-xa",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "description": "Browser-native audio analysis engine: musical timing, BPM/beat tracking, spectral features, and intelligent loop detection",
   "license": "MIT",

--- a/packages/pleco-xa/src/scripts/xa-fileio.js
+++ b/packages/pleco-xa/src/scripts/xa-fileio.js
@@ -340,7 +340,7 @@ export async function find_files(directory, options = {}) {
  */
 export function cite(version = null) {
   // Metadata mirrors packages/pleco-xa/package.json (name, author, repository).
-  const libVersion = version || '2.0.4';
+  const libVersion = version || '2.0.5';
 
   const citation = `@software{pleco_xa,
   title        = {pleco-xa: Browser-native audio analysis engine},


### PR DESCRIPTION
Docs release: VERIFICATION.md ships in the tarball; npm page gets current counts (47/420), static size badge, linked author. Gates: build 0, types 0, 420/420.