### PR TITLE
Label the fingerprint pipeline honestly: supervised stem-guided matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ everywhere, so the same code runs in browsers, Node, and Web Workers.
   capability (the name is an Echoplex homage).
 - **Real-time** — worker-safe streaming analyzers and a live tempo tier,
   analyzing audio as it plays in the browser.
-- **Pure-DSP vocal separation** — surprisingly capable, with no trained model,
-  no weights, and no GPU. Runs in a browser tab.
+- **Pure-DSP source separation** — median-filter HPSS and REPET-SIM-style
+  masking, with no trained model, no weights, and no GPU; plus a supervised
+  stem-guided vocal-matching pipeline. Runs in a browser tab.
 - **Explicit tiers, never silent** — quality is the default; fast/live variants
   are separate named calls; failures throw with diagnostics rather than
   fabricating a number.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Overview: [the guides index](guides/index.md)
 **Transformation & separation**
 
 - [Effects](guides/effects.md) — phase vocoder time-stretch/pitch-shift, trim/split, remix
-- [Decompose](guides/decompose.md) — HPSS, soft masking, pure-DSP vocal separation
+- [Decompose](guides/decompose.md) — HPSS, soft masking, REPET-SIM-style filtering, and supervised stem-guided vocal matching
 
 **Primitives**
 

--- a/docs/api-by-category.md
+++ b/docs/api-by-category.md
@@ -197,9 +197,9 @@ The complete public API, grouped by task. Click any function for its full signat
 | --- | --- |
 | [`decompose.hpss`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/hpss/) | Median-filtering harmonic/percussive source separation on a spectrogram. |
 | [`decompose.nn_filter`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/nn_filter/) | Nearest-neighbor filtering (nn_filter). |
-| [`decompose.optimizeEqCurves`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/optimizeeqcurves/) | Optimize EQ curves to match mixture fingerprints to vocal fingerprints |
-| [`decompose.processAudioToFingerprints`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/processaudiotofingerprints/) | Process audio to create complete fingerprint |
-| [`decompose.reconstructVocal`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/reconstructvocal/) | Reconstruct vocal audio using learned EQ curves |
+| [`decompose.optimizeEqCurves`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/optimizeeqcurves/) | Optimize EQ curves matching mixture fingerprints to reference vocal fingerprints — stem-guided spectral matching (supervised: requires the isolated vocal stem as target) |
+| [`decompose.processAudioToFingerprints`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/processaudiotofingerprints/) | Multi-scale spectral fingerprints — entry point of the stem-guided (supervised) matching pipeline |
+| [`decompose.reconstructVocal`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/reconstructvocal/) | Reconstruct a vocal estimate from EQ curves learned against a reference stem (supervised — not blind separation; for that use hpss/softmask/nn_filter) |
 | [`decompose.softmask`](https://plecoxa.com/api/pleco-xa/namespaces/decompose/functions/softmask/) | Robust soft mask M = X^power / (X^power + X_ref^power), computed with a rescale-by-max stabilization. |
 | [`griffinlim`](https://plecoxa.com/api/functions/griffinlim/) | Griffin-Lim algorithm for phase reconstruction |
 | [`pcen`](https://plecoxa.com/api/functions/pcen/) | Per-Channel Energy Normalization (PCEN) |

--- a/docs/gallery/index.mdx
+++ b/docs/gallery/index.mdx
@@ -20,9 +20,9 @@ import DemoCard from '../../../components/DemoCard.astro'
 ## Vocal separation & decomposition
 
 <div class="demo-grid not-content">
-  <DemoCard title="Vocal separation (flagship)" href="/demos/vocal-separation.html" thumb="/gallery-thumbs/vocal-separation.png" desc="FLAGSHIP: multi-scale fingerprint vocal separation" />
-  <DemoCard title="REPET-SIM vs fingerprint" href="/demos/plot-vocal-separation.html" thumb="/gallery-thumbs/plot-vocal-separation.png" desc="REPET-SIM vs fingerprint separation on a real mix" />
-  <DemoCard title="Vocal sep on real stems" href="/demos/vocal-separation-real.html" thumb="/gallery-thumbs/vocal-separation-real.png" desc="vocal separation on REAL Orphans stems (REPET-SIM vs fingerprint)" />
+  <DemoCard title="Fingerprint vocal matching (supervised)" href="/demos/vocal-separation.html" thumb="/gallery-thumbs/vocal-separation.png" desc="stem-guided multi-scale fingerprint matching — supervised, scored against the stems it is given" />
+  <DemoCard title="REPET-SIM vs fingerprint" href="/demos/plot-vocal-separation.html" thumb="/gallery-thumbs/plot-vocal-separation.png" desc="unsupervised REPET-SIM vs supervised fingerprint matching on a real mix" />
+  <DemoCard title="Vocal estimates on real stems" href="/demos/vocal-separation-real.html" thumb="/gallery-thumbs/vocal-separation-real.png" desc="REAL Orphans stems: unsupervised REPET-SIM vs supervised stem-guided fingerprint" />
   <DemoCard title="HPSS decomposition" href="/demos/decompose-hpss.html" thumb="/gallery-thumbs/decompose-hpss.png" desc="decompose: HPSS spectrogram triptych" />
   <DemoCard title="HPSS margins" href="/demos/plot-hprss.html" thumb="/gallery-thumbs/plot-hprss.png" desc="HPSS margins" />
 </div>

--- a/docs/guides/decompose.md
+++ b/docs/guides/decompose.md
@@ -1,15 +1,17 @@
 ---
-title: Decompose — HPSS, masks, and vocal separation
-description: Pleco-Xa's decompose namespace — one canonical median-filter HPSS, soft masking, nearest-neighbour filtering, and the pure-DSP vocal-separation flagship.
+title: Decompose — HPSS, masks, and source separation
+description: Pleco-Xa's decompose namespace — one canonical median-filter HPSS, soft masking, nearest-neighbour (REPET-SIM-style) filtering, and a supervised stem-guided vocal-matching pipeline.
 ---
 
-`decompose` operates on spectrograms. It carries Pleco-Xa's single canonical
-harmonic/percussive source separation (HPSS), the soft-mask primitive underneath it,
-nearest-neighbour filtering for REPET-SIM-style repetition removal, and Pleco-Xa's own
-**vocal-separation flagship** — a multi-scale spectral fingerprinting pipeline that pulls a
-vocal out of a mix using nothing but DSP. There is no machine-learning model anywhere in
-this namespace: zero weights, zero inference runtime, no ONNX, just median filters, masks,
-and gradient-optimised EQ curves.
+`decompose` operates on spectrograms. Its separation story is **blind (unsupervised)
+source separation**: Pleco-Xa's single canonical harmonic/percussive separation (HPSS),
+the soft-mask primitive underneath it, and nearest-neighbour filtering for REPET-SIM-style
+repetition removal — these need nothing but the mixture. Alongside them sits a multi-scale
+spectral-fingerprinting pipeline for **stem-guided spectral matching (supervised — requires
+reference stems)**: it learns EQ curves that pull the mixture toward fingerprints of a
+vocal stem you supply, so it cannot separate a mix it has no reference for. There is no
+machine-learning model anywhere in this namespace: zero weights, zero inference runtime,
+no ONNX, just median filters, masks, and gradient-optimised EQ curves.
 
 The HPSS/softmask core was validated against reference fixtures during
 development (including `margin=2`); harmonic + percussive ≈ the input at
@@ -27,12 +29,13 @@ Verified against the built barrel (`decompose` namespace):
 - **`nn_filter(S, opts)`** — replace each frame by an aggregate of its nearest neighbours in
   a recurrence graph. `aggregate: 'median'` + `metric: 'cosine'` + a width band is the
   REPET-SIM configuration.
-- **`processAudioToFingerprints(audioBuffer, nFft?, hopLength?)`** — the vocal-separation
-  entry point: multi-scale spectral fingerprints from an `AudioBuffer`-shaped input.
+- **`processAudioToFingerprints(audioBuffer, nFft?, hopLength?)`** — the stem-guided
+  matching entry point: multi-scale spectral fingerprints from an `AudioBuffer`-shaped input.
 - **`optimizeEqCurves(vocalFps, mixtureFps, mixtureMag, numWindows, sr, ...)`** — gradient
-  descent for the per-window EQ curves that isolate the vocal.
+  descent for the per-window EQ curves that match the mixture to the reference vocal's
+  fingerprints (supervised — the optimization target comes from the isolated stem).
 - **`reconstructVocal(mixtureStft, eqCurves, sr, nFft?, hopLength?)`** → `Float32Array` of
-  the reconstructed vocal.
+  the reconstructed vocal estimate.
 
 > **Two HPSS entry points, on purpose.** `decompose.hpss(S, …)` takes a **spectrogram** and
 > returns spectrograms. [`effects.hpss(y, …)`](https://plecoxa.com/api/pleco-xa/namespaces/effects/functions/hpss/)
@@ -63,10 +66,13 @@ const foreground = decompose.nn_filter(S, {
   soft masks so the components sum back to the input — you get separated layers, not the
   bare median-filtered spectrograms. `kernel_size` default is 31; margins must be
   `>= 1`.
-- **Vocal separation input only needs `{ getChannelData, sampleRate }`** — it runs in Node
-  against a structural mock, no browser required. `optimizeEqCurves`/`reconstructVocal`
-  report progress through the library's debug logger, silent unless you call
-  `setDebug(true)`; the flagship's exact multi-stage wiring
+- **The fingerprint pipeline is supervised — it does not do blind separation.** Its
+  optimization target is built from the true isolated vocal, so it needs the reference
+  stem it is matching toward; to separate a mix you only have the mixture of, use
+  `hpss`/`softmask`/`nn_filter`. Input only needs `{ getChannelData, sampleRate }` — it
+  runs in Node against a structural mock, no browser required.
+  `optimizeEqCurves`/`reconstructVocal` report progress through the library's debug
+  logger, silent unless you call `setDebug(true)`; the pipeline's exact multi-stage wiring
   (fingerprints → mixture magnitude → EQ curves → reconstruction) is shown end-to-end in the
   [vocal-separation demo](https://plecoxa.com/demos/vocal-separation.html).
 - **`nn_filter` builds its recurrence graph from

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -46,7 +46,8 @@ section says so precisely.
 - **[Effects](./effects.md)** — a real phase vocoder (time-scale, pitch),
   plus trim/split, pre-emphasis, and remix.
 - **[Decompose](./decompose.md)** — median-filter HPSS, soft masking,
-  nearest-neighbour filtering, and pure-DSP vocal separation.
+  nearest-neighbour (REPET-SIM-style) filtering, and a supervised stem-guided
+  vocal-matching pipeline.
 
 ### Primitives
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -76,9 +76,10 @@ runs in the browser, Node, and Web Workers.
     Worker-safe streaming analyzers and a live tempo tier — analysis that runs
     while the audio plays.
   </Card>
-  <Card title="Pure-DSP vocal separation">
-    Surprisingly capable source separation with no trained model, no weights,
-    and no GPU. It runs in a browser tab.
+  <Card title="Pure-DSP source separation">
+    Median-filter HPSS and REPET-SIM-style masking with no trained model, no
+    weights, and no GPU — plus a supervised stem-guided vocal-matching
+    pipeline. It runs in a browser tab.
   </Card>
 </CardGrid>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,7 +60,7 @@ Just run them — no server needed:
 ```bash
 node examples/node/xa-fft.mjs          # FFT/STFT known-tone proof
 node examples/node/pyin.mjs            # probabilistic-YIN pitch tracking
-node examples/node/vocal-separation-real.mjs   # vocal separation on a real mix
+node examples/node/vocal-separation-real.mjs   # unsupervised REPET-SIM vs supervised fingerprint on a real mix
 ```
 
 Each prints a `PASS`/`FAIL` table and exits `0` only if every proof passes, so

--- a/examples/web/plot-vocal-separation.html
+++ b/examples/web/plot-vocal-separation.html
@@ -39,8 +39,9 @@
   of <code>Orphans</code> (mono, 22.05 kHz) — a full
   band mix with sung vocals. This run has <b>true ground truth</b>: the isolated
   vocal and instrumental stems (from the original session) are loaded separately
-  and used only as references to <i>score</i> each separator. Both separators see
-  only the mixture.
+  and used to <i>score</i> each separator. The REPET-SIM separator sees only the
+  mixture; the fingerprint method is additionally handed the true vocal's
+  fingerprints as its optimization target (supervised).
 </p>
 <p>
   <b>A. REPET-SIM</b> (repetition-based separation, <b>unsupervised</b>):
@@ -48,7 +49,8 @@
   element-min with S → <code>decompose.softmask</code> (margins 2/10, power 2)
   → istft with the mixture phase. It models the <i>repeating</i> background and
   treats the non-repeating residue as foreground.
-  <b>B. Fingerprint</b> (pleco flagship, <span class="note">supervised — it is
+  <b>B. Fingerprint</b> (pleco's stem-guided matching pipeline,
+  <span class="note">supervised — it is
   given the true vocal's fingerprints</span>):
   <code>processAudioToFingerprints</code> → <code>optimizeEqCurves</code> →
   <code>reconstructVocal</code>.

--- a/examples/web/vocal-separation-real.html
+++ b/examples/web/vocal-separation-real.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="description" content="Two different methods pull the vocal out of a real song, and you can listen to every result side by side with the true stems." />
+<meta name="description" content="An unsupervised REPET-SIM baseline and a supervised stem-guided fingerprint method each estimate the vocal of a real song — listen to every result side by side with the true stems." />
 <title>Vocal separation on real stems · pleco-xa</title>
 <style>
   body { font: 15px/1.5 system-ui, sans-serif; background: #181818; color: #eee; max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
@@ -56,7 +56,8 @@
   <code>decompose.nn_filter(|STFT|, median, cosine, width=2 s)</code> →
   element-min with S → <code>decompose.softmask</code> (margins 2/10, power 2)
   → istft with mix phase.
-  <b>B. fingerprint</b> (pleco flagship, <span class="note">supervised — handed
+  <b>B. fingerprint</b> (pleco's stem-guided matching pipeline,
+  <span class="note">supervised — handed
   the true vocal's fingerprints</span>): <code>processAudioToFingerprints</code>
   → <code>optimizeEqCurves</code> → <code>reconstructVocal</code>.
 </p>
@@ -67,7 +68,11 @@
   ordering, but the supervised fingerprint wins vocal fidelity by a clear margin
   (corr voc 0.744 vs REPET 0.438), while REPET's background still retains ~65 %
   of the true instrumental energy. Gate = the fingerprint's vocal-vs-instrumental
-  ordering; REPET's numbers are reported, not hidden.
+  ordering; REPET's numbers are reported, not hidden. Keep the comparison honest:
+  the fingerprint method is <b>supervised</b> — it is scored against the very stem
+  it was handed as its optimization target, so its win demonstrates stem-guided
+  matching, not blind separation. REPET-SIM is the unsupervised baseline; it sees
+  only the mixture.
 </p>
 <div id="status">decoding stems and running both separators…</div>
 <div id="badges"></div>

--- a/examples/web/vocal-separation.html
+++ b/examples/web/vocal-separation.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="description" content="A synthetic singing tone is lifted out of its backing track by learning EQ curves from the vocal's spectral fingerprint, with every stage playable by ear." />
-<title>Fingerprint vocal separation — flagship · pleco-xa</title>
+<meta name="description" content="A supervised, stem-guided demo: EQ curves are learned from the true synthetic vocal's spectral fingerprint and used to pull it back out of the mix, with every stage playable by ear." />
+<title>Fingerprint vocal matching (supervised) · pleco-xa</title>
 <style>
   body { font: 15px/1.5 system-ui, sans-serif; background: #181818; color: #eee; max-width: 860px; margin: 2rem auto; padding: 0 1rem; }
   h1 { font-size: 1.2rem; }
@@ -28,9 +28,9 @@
 <body>
 <header class="px-shell">
   <a href="/gallery/">&larr; Gallery</a>
-  <span class="px-shell-title">Fingerprint vocal separation — flagship</span>
+  <span class="px-shell-title">Fingerprint vocal matching (supervised)</span>
 </header>
-<h1>Fingerprint vocal separation — flagship: separation on a known synthetic mix</h1>
+<h1>Fingerprint vocal matching — supervised, stem-guided, on a known synthetic mix</h1>
 <div style="font:12px monospace;color:#888">scripts/xa-vocal-separation.js</div>
 <p>
   Hear a "vocal" get lifted out of a mix: the library learns EQ curves from the
@@ -42,6 +42,12 @@
   Pipeline: <code>processAudioToFingerprints</code> on vocal and mixture →
   <code>optimizeEqCurves</code> (100 iters) → <code>reconstructVocal</code> on
   the mixture STFT.
+  <b>Honest framing:</b> this pipeline is <b>supervised</b> — it is handed the
+  true vocal (its fingerprints are the optimization target) and is scored
+  against the very parts it was given. That demonstrates stem-guided spectral
+  matching, not blind separation; the unsupervised baseline is REPET-SIM
+  (<code>decompose.nn_filter</code> + <code>decompose.softmask</code>) and HPSS
+  (<code>decompose.hpss</code>), compared head-to-head in the real-stems demos.
   <b>Honest note:</b> the optimizer is plain full-batch gradient descent with
   NO input normalization — stability requires <code>lr &lt; 1/max(|STFT|)²</code>.
   At the natural signal levels here that means <code>lr = 1e-5</code>

--- a/llms.txt
+++ b/llms.txt
@@ -158,7 +158,7 @@ Import: `import { tempo, feature, loop, segment, sequence, decompose, convert } 
 | Loops | `loop.detect` (one entry, 4 strategies) | `detectLoop`, `fastLoopAnalysis`, `loop.loopAnalysis`, `loop.fastOnsetLoopAnalysis`, `loop.analyzeLoopPoints`, `loop.xaLoopAnalysis` |
 | Onsets | `onset_strength` (envelope) \| `onsetDetect` (event times) | `bpm.computeOnsetStrength` |
 | Spectral features | `feature.*` (melspectrogram, mfcc, chroma_stft, spectral_*) | top-level `spectrogram` (bare magnitude helper) |
-| Separation | `decompose.hpss` / `decompose.nn_filter` / `decompose.softmask` | `decompose.processAudioToFingerprints` / `reconstructVocal` / `optimizeEqCurves` (specialized vocal-EQ pipeline, not general separation) |
+| Separation | `decompose.hpss` / `decompose.nn_filter` / `decompose.softmask` | `decompose.processAudioToFingerprints` / `reconstructVocal` / `optimizeEqCurves` (supervised stem-guided vocal-EQ pipeline — requires reference stems, not blind separation) |
 | Structure | `segment.recurrenceMatrix` / `segment.agglomerative` / `segment.laplacianSegmentation` | `recurrence.*` namespace (`recurrence.recurrenceMatrix`, `recurrence.recurrenceLoopDetection`, `recurrence.computeChroma`) |
 | Alignment | `sequence.dtw` / `sequence.rqa` / `sequence.viterbi` | — (no legacy alignment exports in the barrel) |
 | Pitch | `pyin` (f0 + voicing) \| `yin` (fast f0) | — (piptrack/autocorrelation_pitch not in the barrel) |
@@ -705,9 +705,9 @@ https://plecoxa.com/api-by-category/ (and in the shipped TypeScript declarations
 ### Decomposition & separation
 - `decompose.hpss` — Median-filtering harmonic/percussive source separation on a spectrogram.
 - `decompose.nn_filter` — Nearest-neighbor filtering (nn_filter).
-- `decompose.optimizeEqCurves` — Optimize EQ curves to match mixture fingerprints to vocal fingerprints
-- `decompose.processAudioToFingerprints` — Process audio to create complete fingerprint
-- `decompose.reconstructVocal` — Reconstruct vocal audio using learned EQ curves
+- `decompose.optimizeEqCurves` — Optimize EQ curves matching mixture fingerprints to reference vocal fingerprints — stem-guided spectral matching (supervised: requires the isolated vocal stem as target)
+- `decompose.processAudioToFingerprints` — Multi-scale spectral fingerprints — entry point of the stem-guided (supervised) matching pipeline
+- `decompose.reconstructVocal` — Reconstruct a vocal estimate from EQ curves learned against a reference stem (supervised — not blind separation; for that use hpss/softmask/nn_filter)
 - `decompose.softmask` — Robust soft mask M = X^power / (X^power + X_ref^power), computed with a rescale-by-max stabilization.
 - `griffinlim` — Griffin-Lim algorithm for phase reconstruction
 - `pcen` — Per-Channel Energy Normalization (PCEN)

--- a/packages/pleco-xa/README.md
+++ b/packages/pleco-xa/README.md
@@ -15,7 +15,7 @@
 pleco-xa brings musical intelligence to anything that runs JavaScript — the
 browser, Node, Web Workers, the edge. Tempo and beat tracking; mel / MFCC /
 chroma / spectral descriptors; structural segmentation; DTW & sequence
-alignment; effects; pitch tracking; pure-DSP vocal separation; and its
+alignment; effects; pitch tracking; pure-DSP source separation; and its
 signature **loop detection** — with **zero runtime dependencies** and no build
 step required. 47 CI-gated test suites (420 tests) run on every PR and push
 to `main`, with loop detection locked against committed golden fixtures on
@@ -73,7 +73,7 @@ the analysis API is `(Float32Array, sampleRate)` everywhere.
 | `pleco-xa/convert` | hz ↔ midi ↔ note, time ↔ frames ↔ samples, hz ↔ mel, amplitude ↔ dB |
 | `pleco-xa/segment` | recurrence matrix, agglomerative & Laplacian segmentation |
 | `pleco-xa/sequence` | DTW, Viterbi, RQA, event/interval matching |
-| `pleco-xa/decompose` | HPSS, nn_filter, softmask, fingerprint vocal separation |
+| `pleco-xa/decompose` | HPSS, nn_filter, softmask, stem-guided vocal matching (supervised fingerprint pipeline) |
 | `pleco-xa/effects` | time-stretch, pitch-shift, remix, trim, split |
 | `pleco-xa/filters` | mel & chroma filter banks |
 | `pleco-xa/bpm` | tempo engine |
@@ -90,7 +90,9 @@ the analysis API is `(Float32Array, sampleRate)` everywhere.
   committed golden fixtures on real audio (±10 ms).
 - **Loop detection** — the signature feature.
 - **Real-time** streaming analyzers and a live tempo tier.
-- **Pure-DSP vocal separation** — no model, no weights, no GPU.
+- **Pure-DSP source separation** — median-filter HPSS and REPET-SIM-style
+  masking; no model, no weights, no GPU. Plus a supervised stem-guided
+  vocal-matching pipeline.
 
 ## For AI agents
 

--- a/packages/pleco-xa/src/scripts/xa-vocal-separation.js
+++ b/packages/pleco-xa/src/scripts/xa-vocal-separation.js
@@ -412,7 +412,8 @@ export function windowToFingerprint(window, sr) {
 }
 
 /**
- * Process audio to create complete fingerprint
+ * Process audio to create a complete multi-scale spectral fingerprint
+ * (stage 1 of the supervised stem-guided matching pipeline)
  * @param {AudioBuffer} audioBuffer - Audio buffer
  * @param {number} nFft - FFT window size
  * @param {number} hopLength - Hop length
@@ -467,7 +468,8 @@ export function processAudioToFingerprints(audioBuffer, nFft = 2048, hopLength =
 }
 
 /**
- * Optimize EQ curves to match mixture fingerprints to vocal fingerprints
+ * Optimize EQ curves to match mixture fingerprints to a REFERENCE vocal's
+ * fingerprints (supervised — requires the isolated stem as its target)
  * @param {Object} vocalFps - Vocal fingerprints
  * @param {Object} mixtureFps - Mixture fingerprints (used for initialization context)
  * @param {Array<Array<number>>} mixtureMag - Mixture magnitude spectrogram (freq x time)
@@ -551,7 +553,9 @@ export function optimizeEqCurves(vocalFps, mixtureFps, mixtureMag, numWindows, s
 }
 
 /**
- * Reconstruct vocal audio using learned EQ curves
+ * Reconstruct a vocal ESTIMATE from EQ curves learned against a reference
+ * stem (supervised — not blind separation; for that use decompose.hpss /
+ * softmask / nn_filter)
  * @param {Array} mixtureStft - Mixture STFT in (freq x time) format
  * @param {Array<Array<number>>} eqCurves - EQ curves for each window
  * @param {number} sr - Sample rate

--- a/tools/llms/cards.md
+++ b/tools/llms/cards.md
@@ -14,7 +14,7 @@ Import: `import { tempo, feature, loop, segment, sequence, decompose, convert } 
 | Loops | `loop.detect` (one entry, 4 strategies) | `detectLoop`, `fastLoopAnalysis`, `loop.loopAnalysis`, `loop.fastOnsetLoopAnalysis`, `loop.analyzeLoopPoints`, `loop.xaLoopAnalysis` |
 | Onsets | `onset_strength` (envelope) \| `onsetDetect` (event times) | `bpm.computeOnsetStrength` |
 | Spectral features | `feature.*` (melspectrogram, mfcc, chroma_stft, spectral_*) | top-level `spectrogram` (bare magnitude helper) |
-| Separation | `decompose.hpss` / `decompose.nn_filter` / `decompose.softmask` | `decompose.processAudioToFingerprints` / `reconstructVocal` / `optimizeEqCurves` (specialized vocal-EQ pipeline, not general separation) |
+| Separation | `decompose.hpss` / `decompose.nn_filter` / `decompose.softmask` | `decompose.processAudioToFingerprints` / `reconstructVocal` / `optimizeEqCurves` (supervised stem-guided vocal-EQ pipeline — requires reference stems, not blind separation) |
 | Structure | `segment.recurrenceMatrix` / `segment.agglomerative` / `segment.laplacianSegmentation` | `recurrence.*` namespace (`recurrence.recurrenceMatrix`, `recurrence.recurrenceLoopDetection`, `recurrence.computeChroma`) |
 | Alignment | `sequence.dtw` / `sequence.rqa` / `sequence.viterbi` | — (no legacy alignment exports in the barrel) |
 | Pitch | `pyin` (f0 + voicing) \| `yin` (fast f0) | — (piptrack/autocorrelation_pitch not in the barrel) |


### PR DESCRIPTION
Executes the parked vocal-separation decision (recommended path): HPSS/softmask/nn_filter lead as the blind-separation story; the fingerprint pipeline is labeled supervised/stem-guided everywhere (guides, API index, llms.txt, demos — including one factually false sentence fixed — READMEs, landing, gallery, source JSDoc). Wording only. Gates: lint 0, build:lib 0, types 0, docs 363pp, llms drift stable.